### PR TITLE
Add GitHub Actions workflow for RuboCop

### DIFF
--- a/.github/workflows/.rubocop.yml
+++ b/.github/workflows/.rubocop.yml
@@ -1,0 +1,66 @@
+inherit_from: .rubocop_todo.yml
+name: Lint Ruby Code
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  rubocop:
+    name: Run RuboCop
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.3.0'
+          bundler-cache: true 
+
+      - name: Run RuboCop
+        run: bundle exec rubocop --color
+AllCops:
+
+  NewCops: enable
+  TargetRubyVersion: 3.3.0
+  Exclude:
+    - 'vendor/**/*'
+    - 'spec/fixtures/**/*'
+    - 'tmp/**/*'
+    - '.git/**/*'
+    - 'bin/*'
+  Exclude:
+  <% `git status --ignored --porcelain`.lines.grep(/^!! /).each do |path| %>
+    - <%= path.sub(/^!! /, '').sub(/\/$/, '/**/*') %>
+  <% end %>
+Layout/IndentationWidth:
+  Width: 2
+
+Style/Documentation:
+  Enabled: false
+
+Layout/LineLength:
+  Max: 120
+Style/StringLiterals:
+  EnforcedStyle: single_quotes
+Style/FrozenStringLiteralComment:
+  Enabled: true
+
+Style/IfUnlessModifier:
+  Enabled: true
+Metrics/MethodLength:
+  Max: 20
+require:
+  - rubocop-rails
+
+Rails:
+  StyleGuideBaseURL: https://rails.rubystyle.guide
+  DocumentationBaseURL: https://docs.rubocop.org/rubocop-rails
+Rails/TimeZone:
+  StyleGuide: '#time'
+  


### PR DESCRIPTION
Add GitHub Actions Workflow for RuboCop

This PR adds a CI workflow using GitHub Actions to automatically run RuboCop checks on every push and pull request.

Key changes:
Created a GitHub Actions workflow to run RuboCop
Configured the workflow to trigger on push and pull request events
Ensured consistent code style enforcement across the team
Added automatic linting to catch issues early in the development process
Outcome:

With this workflow in place, code style violations will be detected automatically during CI, helping maintain a clean and consistent codebase and reducing manual review effort.