### PR TITLE
Add environment variable templates and documentation

### DIFF
--- a/api/.env.example
+++ b/api/.env.example
@@ -1,0 +1,18 @@
+# ==========================================
+# DATABASE
+# ==========================================
+# If Postgres requires a specific user/password on your local machine
+DB_USERNAME=
+DB_PASSWORD=
+
+# ==========================================
+# SECURITY
+# ==========================================
+# Run `bin/rails secret` in your terminal to generate a secure random string for this!
+JWT_SECRET_KEY=
+
+# ==========================================
+# CORS / FRONTEND
+# ==========================================
+# Tell Rails who is allowed to talk to the API
+FRONTEND_URL=

--- a/api/.env.example
+++ b/api/.env.example
@@ -10,7 +10,7 @@ DB_PORT=
 # ==========================================
 # SECURITY
 # ==========================================
-# Run `bin/rails secret` in your terminal to generate a secure random string for this!
+# From the repo root, run `cd api && bin/rails secret` to generate a secure random string for this!
 JWT_SECRET_KEY=
 
 # ==========================================

--- a/api/.env.example
+++ b/api/.env.example
@@ -4,6 +4,8 @@
 # If Postgres requires a specific user/password on your local machine
 DB_USERNAME=
 DB_PASSWORD=
+DB_HOST=
+DB_PORT=
 
 # ==========================================
 # SECURITY
@@ -12,7 +14,6 @@ DB_PASSWORD=
 JWT_SECRET_KEY=
 
 # ==========================================
-# CORS / FRONTEND
+# SWAGGER
 # ==========================================
-# Tell Rails who is allowed to talk to the API
-FRONTEND_URL=
+SWAGGER_SERVER_URL=

--- a/api/Gemfile
+++ b/api/Gemfile
@@ -9,6 +9,7 @@ gem 'bootsnap', require: false
 gem 'brakeman', '~> 8.0', groups: %i[development test]
 gem 'bundler-audit', '~> 0.9.3', groups: %i[development test]
 gem 'devise'
+gem 'dotenv-rails'
 gem 'jwt'
 gem 'pg', '~> 1.1'
 gem 'puma', '~> 8.0'

--- a/api/Gemfile
+++ b/api/Gemfile
@@ -9,7 +9,7 @@ gem 'bootsnap', require: false
 gem 'brakeman', '~> 8.0', groups: %i[development test]
 gem 'bundler-audit', '~> 0.9.3', groups: %i[development test]
 gem 'devise'
-gem 'dotenv-rails'
+gem 'dotenv-rails', groups: %i[development test]
 gem 'jwt'
 gem 'pg', '~> 1.1'
 gem 'puma', '~> 8.0'

--- a/api/Gemfile.lock
+++ b/api/Gemfile.lock
@@ -103,6 +103,10 @@ GEM
       warden (~> 1.2.3)
     diff-lcs (1.6.2)
     docile (1.4.1)
+    dotenv (3.2.0)
+    dotenv-rails (3.2.0)
+      dotenv (= 3.2.0)
+      railties (>= 6.1)
     drb (2.2.3)
     erb (6.0.2)
     erubi (1.13.1)
@@ -356,6 +360,7 @@ DEPENDENCIES
   brakeman (~> 8.0)
   bundler-audit (~> 0.9.3)
   devise
+  dotenv-rails
   factory_bot_rails
   faker
   jwt

--- a/api/README.md
+++ b/api/README.md
@@ -62,7 +62,7 @@ The report provides detailed information on which lines of code are covered by t
 ### Run server
 
 ```shell
-rails s -p 7000
+rails s -p 3000
 ```
 
 

--- a/api/app/services/jwt_service.rb
+++ b/api/app/services/jwt_service.rb
@@ -1,7 +1,10 @@
 # frozen_string_literal: true
 
 class JwtService
-  SECRET_KEY = ENV.fetch('JWT_SECRET_KEY') { Rails.application.secret_key_base.to_s }
+  env_secret = ENV['JWT_SECRET_KEY'].presence
+  SECRET_KEY = env_secret || Rails.application.secret_key_base.to_s
+  raise 'JWT_SECRET_KEY must be set in production' if Rails.env.production? && env_secret.blank?
+
   ALGORITHM = 'HS256'
 
   def self.encode(payload, exp = 24.hours.from_now)

--- a/api/app/services/jwt_service.rb
+++ b/api/app/services/jwt_service.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class JwtService
-  SECRET_KEY = Rails.application.secret_key_base.to_s
+  SECRET_KEY = ENV.fetch('JWT_SECRET_KEY') { Rails.application.secret_key_base.to_s }
   ALGORITHM = 'HS256'
 
   def self.encode(payload, exp = 24.hours.from_now)

--- a/api/config/database.yml
+++ b/api/config/database.yml
@@ -18,8 +18,8 @@ default: &default
   # For details on connection pooling, see Rails configuration guide
   # https://guides.rubyonrails.org/configuring.html#database-pooling
   max_connections: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
-  username: <%= ENV.fetch("DB_USERNAME", "postgres") %>
-  password: <%= ENV.fetch("DB_PASSWORD", "") %>
+  username: <%= ENV["DB_USERNAME"].presence %>
+  password: <%= ENV["DB_PASSWORD"].presence %>
 
 development:
   <<: *default

--- a/api/config/database.yml
+++ b/api/config/database.yml
@@ -20,6 +20,8 @@ default: &default
   max_connections: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
   username: <%= ENV["DB_USERNAME"].presence %>
   password: <%= ENV["DB_PASSWORD"].presence %>
+  host: <%= ENV["DB_HOST"].presence %>
+  port: <%= ENV["DB_PORT"].presence %>
 
 development:
   <<: *default

--- a/api/config/database.yml
+++ b/api/config/database.yml
@@ -18,7 +18,8 @@ default: &default
   # For details on connection pooling, see Rails configuration guide
   # https://guides.rubyonrails.org/configuring.html#database-pooling
   max_connections: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
-
+  username: <%= ENV.fetch("DB_USERNAME", "postgres") %>
+  password: <%= ENV.fetch("DB_PASSWORD", "") %>
 
 development:
   <<: *default

--- a/api/config/initializers/rswag_api.rb
+++ b/api/config/initializers/rswag_api.rb
@@ -1,15 +1,10 @@
 # frozen_string_literal: true
 
-Rswag::Api.configure do |c|
-  # Specify a root folder where Swagger JSON files are located
-  # This is used by the Swagger middleware to serve requests for API descriptions
-  # NOTE: If you're using rswag-specs to generate Swagger, you'll need to ensure
-  # that it's configured to generate files in the same folder
-  c.openapi_root = "#{Rails.root}/swagger"
 
-  # Inject a lambda function to alter the returned Swagger prior to serialization
-  # The function will have access to the rack env for the current request
-  # For example, you could leverage this to dynamically assign the "host" property
-  #
-  # c.swagger_filter = lambda { |swagger, env| swagger['host'] = env['HTTP_HOST'] }
+Rswag::Api.configure do |c|
+  c.openapi_root = File.join(Rails.root, "swagger")
+  c.swagger_filter = lambda do |swagger, env|
+    base = ENV["SWAGGER_SERVER_URL"].presence || "#{env['rack.url_scheme']}://#{env['HTTP_HOST']}"
+    swagger["servers"] = [ { "url" => base } ]
+  end
 end

--- a/api/config/initializers/rswag_api.rb
+++ b/api/config/initializers/rswag_api.rb
@@ -1,10 +1,9 @@
 # frozen_string_literal: true
 
-
 Rswag::Api.configure do |c|
-  c.openapi_root = File.join(Rails.root, "swagger")
+  c.openapi_root = File.join(Rails.root, 'swagger')
   c.swagger_filter = lambda do |swagger, env|
-    base = ENV["SWAGGER_SERVER_URL"].presence || "#{env['rack.url_scheme']}://#{env['HTTP_HOST']}"
-    swagger["servers"] = [ { "url" => base } ]
+    base = ENV['SWAGGER_SERVER_URL'].presence || "#{env['rack.url_scheme']}://#{env['HTTP_HOST']}"
+    swagger['servers'] = [{ 'url' => base }]
   end
 end

--- a/api/spec/swagger_helper.rb
+++ b/api/spec/swagger_helper.rb
@@ -14,7 +14,7 @@ RSpec.configure do |config|
         description: 'API documentation for the Eventify platform'
       },
       servers: [
-        { url: ENV.fetch('SWAGGER_SERVER_URL'), description: 'Local server' }
+        { url: ENV.fetch('SWAGGER_SERVER_URL', 'http://127.0.0.1:3000'), description: 'Local server' }
       ],
       components: {
         securitySchemes: {

--- a/api/spec/swagger_helper.rb
+++ b/api/spec/swagger_helper.rb
@@ -14,7 +14,7 @@ RSpec.configure do |config|
         description: 'API documentation for the Eventify platform'
       },
       servers: [
-        { url: 'http://localhost:3000', description: 'Local server' }
+        { url: ENV.fetch('SWAGGER_SERVER_URL'), description: 'Local server' }
       ],
       components: {
         securitySchemes: {

--- a/docs/ENV_USAGE.md
+++ b/docs/ENV_USAGE.md
@@ -5,27 +5,34 @@ We use the `dotenv-rails` gem to manage environment variables for local developm
 ## Getting Started
 
 **1. Create your local `.env` file**
-Create the `.env` file inside `api/` (this is `Rails.root`), not in the repository root. From the project root, run:
-```bash
-cd api && cp .env.example .env
-```
+
+  Create the `.env` file inside `api/` (this is `Rails.root`), not in the repository root. From the project root, run:
+  
+  ```bash
+  cd api && cp .env.example .env
+  ```
 
 **2. Generate a local JWT Secret**
-You need a unique, cryptographically secure string to sign your local JSON Web Tokens. Run this command in your terminal to generate one:
-```bash
-cd api && bin/rails secret
-```
-*Copy the long string it outputs.*
+
+  You need a unique, cryptographically secure string to sign your local JSON Web Tokens. Run this command in your terminal to generate one:
+
+  ```bash
+  cd api && bin/rails secret
+  ```
+  
+  *Copy the long string it outputs.*
 
 **3. Populate your `.env` file**
-Open your newly created `.env` file and fill in your specific values:
-* `DB_USERNAME`: Your local Postgres username (often `postgres`).
-* `DB_PASSWORD`: Your local Postgres password (leave blank if you don't use one).
-* `JWT_SECRET_KEY`: Paste the secret string generated in Step 2.
-* `FRONTEND_URL`: Set this explicitly to the local URL of our frontend application (for local development, this is usually `http://localhost:5173`).
+  
+  Open your newly created `.env` file and fill in your specific values:
+  * `DB_USERNAME`: Your local Postgres username (often `postgres`).
+  * `DB_PASSWORD`: Your local Postgres password (leave blank if you don't use one).
+  * `JWT_SECRET_KEY`: Paste the secret string generated in Step 2.
+  * `FRFRSWAGGER_SERVER_URL`: Set this explicitly to the local URL of our Swagger UI application (for local development, this is usually `http://localhost:3000`)
 
 ---
 
 ## ⚠️ CRITICAL RULES FOR THE TEAM
+
 * **NEVER commit your real `api/.env` file**.
 * **Always update `api/.env.example`** when adding new required variables.

--- a/docs/ENV_USAGE.md
+++ b/docs/ENV_USAGE.md
@@ -28,7 +28,7 @@ We use the `dotenv-rails` gem to manage environment variables for local developm
   * `DB_USERNAME`: Your local Postgres username (often `postgres`).
   * `DB_PASSWORD`: Your local Postgres password (leave blank if you don't use one).
   * `JWT_SECRET_KEY`: Paste the secret string generated in Step 2.
-  * `FRFRSWAGGER_SERVER_URL`: Set this explicitly to the local URL of our Swagger UI application (for local development, this is usually `http://localhost:3000`)
+  * `SWAGGER_SERVER_URL`: Set this explicitly to the local URL of our Swagger UI application (for local development, this is usually `http://localhost:3000`)
 
 ---
 

--- a/docs/ENV_USAGE.md
+++ b/docs/ENV_USAGE.md
@@ -1,8 +1,8 @@
-## 🔐 Environment Variables & Local Setup
+# 🔐 Environment Variables & Local Setup
 
 We use the `dotenv-rails` gem to manage environment variables for local development. This ensures our secrets (like JWT keys) remain secure and out of version control, while allowing every developer to configure their own local database credentials.
 
-### Getting Started
+## Getting Started
 
 **1. Create your local `.env` file**
 Run the following command in the project root:
@@ -22,10 +22,10 @@ Open your newly created `.env` file and fill in your specific values:
 * `DB_USERNAME`: Your local Postgres username (often `postgres`).
 * `DB_PASSWORD`: Your local Postgres password (leave blank if you don't use one).
 * `JWT_SECRET_KEY`: Paste the secret string generated in Step 2.
-* `FRONTEND_URL`: The local URL of our frontend application (default: `http://localhost:5173`).
+* `FRONTEND_URL`: Set this explicitly to the local URL of our frontend application (for local development, this is usually `http://localhost:5173`).
 
 ---
 
-### ⚠️ CRITICAL RULES FOR THE TEAM
-* **NEVER commit your `.env` file.** It is already listed in our `.gitignore`.
-* **Always update `.env.example`.** If you add a new environment variable to the codebase (e.g., an AWS Key or a 3rd-party API token), you **must** add a blank/placeholder version of it to `.env.example` and commit that change. This ensures the rest of the team knows they need to add it to their local setups.
+## ⚠️ CRITICAL RULES FOR THE TEAM
+* **NEVER commit your real `api/.env` file**.
+* **Always update `api/.env.example`** when adding new required variables.

--- a/docs/ENV_USAGE.md
+++ b/docs/ENV_USAGE.md
@@ -1,0 +1,39 @@
+Here is a clean, formatted block of markdown that you can copy and paste directly into your project's `README.md`. 
+
+It gives your team exactly what they need to know without being overly wordy, and emphasizes the golden rule of never committing the real file.
+
+***
+
+```markdown
+## 🔐 Environment Variables & Local Setup
+
+We use the `dotenv-rails` gem to manage environment variables for local development. This ensures our secrets (like JWT keys) remain secure and out of version control, while allowing every developer to configure their own local database credentials.
+
+### Getting Started
+
+**1. Create your local `.env` file**
+Run the following command in the root of the project to copy the safe template:
+```bash
+cp .env.example .env
+```
+
+**2. Generate a local JWT Secret**
+You need a unique, cryptographically secure string to sign your local JSON Web Tokens. Run this command in your terminal to generate one:
+```bash
+bin/rails secret
+```
+*Copy the long string it outputs.*
+
+**3. Populate your `.env` file**
+Open your newly created `.env` file and fill in your specific values:
+* `DB_USERNAME`: Your local Postgres username (often `postgres`).
+* `DB_PASSWORD`: Your local Postgres password (leave blank if you don't use one).
+* `JWT_SECRET_KEY`: Paste the secret string you generated in Step 2.
+* `FRONTEND_URL`: The local URL of our frontend application (default: `http://localhost:5173`).
+
+---
+
+### ⚠️ CRITICAL RULES FOR THE TEAM
+* **NEVER commit your `.env` file.** It is already listed in our `.gitignore`.
+* **Always update `.env.example`.** If you add a new environment variable to the codebase (e.g., an AWS Key or a 3rd-party API token), you **must** add a blank/placeholder version of it to `.env.example` and commit that change. This ensures the rest of the team knows they need to add it to their local setups.
+```

--- a/docs/ENV_USAGE.md
+++ b/docs/ENV_USAGE.md
@@ -1,10 +1,3 @@
-Here is a clean, formatted block of markdown that you can copy and paste directly into your project's `README.md`. 
-
-It gives your team exactly what they need to know without being overly wordy, and emphasizes the golden rule of never committing the real file.
-
-***
-
-```markdown
 ## 🔐 Environment Variables & Local Setup
 
 We use the `dotenv-rails` gem to manage environment variables for local development. This ensures our secrets (like JWT keys) remain secure and out of version control, while allowing every developer to configure their own local database credentials.
@@ -12,15 +5,15 @@ We use the `dotenv-rails` gem to manage environment variables for local developm
 ### Getting Started
 
 **1. Create your local `.env` file**
-Run the following command in the root of the project to copy the safe template:
+Run the following command in the project root:
 ```bash
-cp .env.example .env
+cp api/.env.example api/.env
 ```
 
 **2. Generate a local JWT Secret**
 You need a unique, cryptographically secure string to sign your local JSON Web Tokens. Run this command in your terminal to generate one:
 ```bash
-bin/rails secret
+cd api && bin/rails secret
 ```
 *Copy the long string it outputs.*
 
@@ -28,7 +21,7 @@ bin/rails secret
 Open your newly created `.env` file and fill in your specific values:
 * `DB_USERNAME`: Your local Postgres username (often `postgres`).
 * `DB_PASSWORD`: Your local Postgres password (leave blank if you don't use one).
-* `JWT_SECRET_KEY`: Paste the secret string you generated in Step 2.
+* `JWT_SECRET_KEY`: Paste the secret string generated in Step 2.
 * `FRONTEND_URL`: The local URL of our frontend application (default: `http://localhost:5173`).
 
 ---
@@ -36,4 +29,3 @@ Open your newly created `.env` file and fill in your specific values:
 ### ⚠️ CRITICAL RULES FOR THE TEAM
 * **NEVER commit your `.env` file.** It is already listed in our `.gitignore`.
 * **Always update `.env.example`.** If you add a new environment variable to the codebase (e.g., an AWS Key or a 3rd-party API token), you **must** add a blank/placeholder version of it to `.env.example` and commit that change. This ensures the rest of the team knows they need to add it to their local setups.
-```

--- a/docs/ENV_USAGE.md
+++ b/docs/ENV_USAGE.md
@@ -5,9 +5,9 @@ We use the `dotenv-rails` gem to manage environment variables for local developm
 ## Getting Started
 
 **1. Create your local `.env` file**
-Run the following command in the project root:
+Create the `.env` file inside `api/` (this is `Rails.root`), not in the repository root. From the project root, run:
 ```bash
-cp api/.env.example api/.env
+cd api && cp .env.example .env
 ```
 
 **2. Generate a local JWT Secret**


### PR DESCRIPTION
### Summary
This PR introduces the `dotenv-rails` gem to safely manage local environment variables and keep secrets out of version control. It migrates our local database credentials and JWT secret key to a `.env` file while maintaining a graceful fallback for existing setups.

### Key Changes
* **Dependency:** Added `dotenv-rails` to the `development` and `test` groups.
* **Security:** Appended `.env` to `.gitignore` to ensure secrets are never committed.
* **Configuration:**
  * Created `.env.example` as a safe template for the team.
  * Updated `config/database.yml` to read `DB_USERNAME` and `DB_PASSWORD` from the environment if present.
  * Updated `JwtService` to fetch `JWT_SECRET_KEY` from the environment, falling back to `Rails.application.secret_key_base` to prevent crashes for unconfigured local setups.
* **Documentation:** Added a local setup guide to `docs/ENV_USAGE.md`.

### ⚠️ Reviewer Action Required
To get your local server running after pulling this branch:
1. Run `bundle install`
2. Run `cp .env.example .env`
3. Run `bin/rails secret`, copy the output, and paste it as your `JWT_SECRET_KEY` in your new `.env` file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added local env support and a development/test dependency to load .env files.
  * Database credentials can be supplied via environment variables and now apply across environments.
  * Authentication now respects an explicit JWT secret from the environment; production will fail fast if unset.

* **Documentation**
  * Added a guide and example env file with step-by-step instructions for generating and managing required secrets and local setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->