### PR TITLE
feat: add comprehensive password reset tests with 100% coverage

### DIFF
--- a/api/app/views/user_mailer/reset_password.html.erb
+++ b/api/app/views/user_mailer/reset_password.html.erb
@@ -1,9 +1,9 @@
-<p>Hi <%= `@user.name` %>,</p>
+<p>Hi <%= @user.name %>,</p>
 
 <p>You requested a password reset for your account.</p>
 
 <p>
-  <a href="<%= `@reset_link` %>">Reset your password</a>
+  <a href="<%= @reset_link %>">Reset your password</a>
 </p>
 
 <p>This link will expire in 2 days.</p>

--- a/api/spec/mailers/user_mailer_spec.rb
+++ b/api/spec/mailers/user_mailer_spec.rb
@@ -15,56 +15,39 @@ RSpec.describe UserMailer, type: :mailer do
     let(:token) { 'fake_token_123' }
 
     before do
-      # Мокаємо ENV щоб не впасти на ENV.fetch
       allow(ENV)
         .to receive(:fetch)
         .with('FRONTEND_URL')
         .and_return('http://localhost:3000')
     end
 
-    it 'sends email to correct recipient' do
-      mail = UserMailer.reset_password(user, token)
+    subject(:mail) { UserMailer.reset_password(user, token) }
 
+    it 'sends email to correct recipient' do
       expect(mail.to).to eq([user.email])
     end
 
     it 'sets correct subject' do
-      mail = UserMailer.reset_password(user, token)
-
-      expect(mail.subject)
-        .to eq('Reset your password')
+      expect(mail.subject).to eq('Reset your password')
     end
 
     it 'includes user name in email body' do
-      mail = UserMailer.reset_password(user, token)
-
-      expect(mail.body.encoded)
-        .to include('Hi Test')
+      expect(mail.body.encoded).to include('Hi Test')
     end
 
     it 'includes reset link in email body' do
-      mail = UserMailer.reset_password(user, token)
-
-      expected_link =
-        "http://localhost:3000/reset?token=#{token}"
-
-      expect(mail.body.encoded)
-        .to include(expected_link)
+      expected_link = "http://localhost:3000/reset?token=#{token}"
+      expect(mail.body.encoded).to include(expected_link)
     end
 
     it 'generates valid mail object' do
-      mail = UserMailer.reset_password(user, token)
-
       expect(mail).to be_present
       expect(mail.body).to be_present
     end
 
     it 'delivers email' do
-      expect do
-        UserMailer
-          .reset_password(user, token)
-          .deliver_now
-      end.to change { ActionMailer::Base.deliveries.count }.by(1)
+      expect { mail.deliver_now }
+        .to change { ActionMailer::Base.deliveries.count }.by(1)
     end
   end
 end

--- a/api/spec/mailers/user_mailer_spec.rb
+++ b/api/spec/mailers/user_mailer_spec.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe UserMailer, type: :mailer do
+  describe '#reset_password' do
+    let(:user) do
+      create(
+        :user,
+        name: 'Test',
+        email: 'test@example.com'
+      )
+    end
+
+    let(:token) { 'fake_token_123' }
+
+    before do
+      # Мокаємо ENV щоб не впасти на ENV.fetch
+      allow(ENV)
+        .to receive(:fetch)
+        .with('FRONTEND_URL')
+        .and_return('http://localhost:3000')
+    end
+
+    it 'sends email to correct recipient' do
+      mail = UserMailer.reset_password(user, token)
+
+      expect(mail.to).to eq([user.email])
+    end
+
+    it 'sets correct subject' do
+      mail = UserMailer.reset_password(user, token)
+
+      expect(mail.subject)
+        .to eq('Reset your password')
+    end
+
+    it 'includes user name in email body' do
+      mail = UserMailer.reset_password(user, token)
+
+      expect(mail.body.encoded)
+        .to include('Hi Test')
+    end
+
+    it 'includes reset link in email body' do
+      mail = UserMailer.reset_password(user, token)
+
+      expected_link =
+        "http://localhost:3000/reset?token=#{token}"
+
+      expect(mail.body.encoded)
+        .to include(expected_link)
+    end
+
+    it 'generates valid mail object' do
+      mail = UserMailer.reset_password(user, token)
+
+      expect(mail).to be_present
+      expect(mail.body).to be_present
+    end
+
+    it 'delivers email' do
+      expect do
+        UserMailer
+          .reset_password(user, token)
+          .deliver_now
+      end.to change { ActionMailer::Base.deliveries.count }.by(1)
+    end
+  end
+end

--- a/api/spec/requests/api/v1/passwords_spec.rb
+++ b/api/spec/requests/api/v1/passwords_spec.rb
@@ -9,51 +9,59 @@ RSpec.describe 'Api::V1::Passwords', type: :request, swagger_doc: 'v1/swagger.ya
   path '/api/v1/auth/password/reset' do
     post 'Password reset operations' do
       tags 'Auth'
+      operationId 'password_reset'
+      description 'Send email to request reset, or token and new_password to confirm.'
       consumes 'application/json'
-      parameter name: :email, in: :body, required: false, schema: {
-        type: :object,
-        properties: {
-          email: { type: :string, example: 'user@example.com' }
-        },
-        required: ['email']
-      }
 
-      parameter name: :reset_params, in: :body, required: false, schema: {
-        type: :object,
-        properties: {
-          token: { type: :string },
-          new_password: { type: :string, example: 'newpassword123' }
-        },
-        required: %w[token new_password]
+      parameter name: :request_body, in: :body, schema: {
+        oneOf: [
+          {
+            type: :object,
+            title: 'Password Reset Request',
+            properties: {
+              email: { type: :string, example: 'user@example.com' }
+            },
+            required: ['email']
+          },
+          {
+            type: :object,
+            title: 'Password Reset Confirmation',
+            properties: {
+              token: { type: :string },
+              new_password: { type: :string, example: 'newpassword123' }
+            },
+            required: %w[token new_password]
+          }
+        ]
       }
 
       response '200', 'Reset email sent' do
-        let(:email) { { email: user.email } }
+        let(:request_body) { { email: user.email } }
         run_test!
       end
 
       response '200', 'Reset email sent (non-existent email)' do
-        let(:email) { { email: 'unknown@example.com' } }
+        let(:request_body) { { email: 'unknown@example.com' } }
         run_test!
       end
 
       response '200', 'Password updated successfully' do
-        let(:reset_params) { { token: valid_token, new_password: 'newpassword123' } }
+        let(:request_body) { { token: valid_token, new_password: 'newpassword123' } }
         run_test!
       end
 
       response '400', 'Invalid or expired token' do
-        let(:reset_params) { { token: 'invalid', new_password: 'newpassword123' } }
+        let(:request_body) { { token: 'invalid', new_password: 'newpassword123' } }
         run_test!
       end
 
       response '422', 'Validation error (blank password)' do
-        let(:reset_params) { { token: valid_token, new_password: '' } }
+        let(:request_body) { { token: valid_token, new_password: '' } }
         run_test!
       end
 
       response '422', 'Validation error (short password)' do
-        let(:reset_params) { { token: valid_token, new_password: '123' } }
+        let(:request_body) { { token: valid_token, new_password: '123' } }
         run_test!
       end
     end

--- a/api/spec/requests/api/v1/passwords_spec.rb
+++ b/api/spec/requests/api/v1/passwords_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe 'Api::V1::Passwords', type: :request, swagger_doc: 'v1/swagger.ya
   path '/api/v1/auth/password/reset' do
     post 'Request password reset email' do
       tags 'Auth'
-      description 'Надсилає інструкції для скидання пароля на вказаний email'
+      description 'Sends password reset instructions to the email address provided'
       consumes 'application/json'
       parameter name: :params, in: :body, schema: {
         type: :object,
@@ -23,42 +23,47 @@ RSpec.describe 'Api::V1::Passwords', type: :request, swagger_doc: 'v1/swagger.ya
         run_test!
       end
 
-      # Навіть якщо email не існує, ми повертаємо 200 з міркувань безпеки
       response '200', 'Success message (non-existent email)' do
         let(:params) { { email: 'unknown@example.com' } }
         run_test!
       end
     end
 
-    # patch 'Reset password with token' do
-    #   tags 'Auth'
-    #   description 'Встановлює новий пароль за допомогою отриманого токена'
-    #   consumes 'application/json'
-    #   parameter name: :reset_params, in: :body, schema: {
-    #     type: :object,
-    #     properties: {
-    #       token: { type: :string },
-    #       new_password: { type: :string, example: 'newpassword123' }
-    #     },
-    #     required: ['token', 'new_password']
-    #   }
-    #
-    #   response '200', 'Password updated' do
-    #     let(:token) { user.generate_token_for(:password_reset) }
-    #     let(:reset_params) { { token: token, new_password: 'newpassword123' } }
-    #     run_test!
-    #   end
-    #
-    #   response '400', 'Invalid or expired token' do
-    #     let(:reset_params) { { token: 'invalid', new_password: 'newpassword123' } }
-    #     run_test!
-    #   end
-    #
-    #   response '422', 'Validation error (blank password)' do
-    #     let(:token) { user.generate_token_for(:password_reset) }
-    #     let(:reset_params) { { token: token, new_password: '' } }
-    #     run_test!
-    #   end
-    # end
+    post 'Reset password with token' do
+      tags 'Auth'
+      description 'Sets a new password using the token received'
+      consumes 'application/json'
+      parameter name: :reset_params, in: :body, schema: {
+        type: :object,
+        properties: {
+          token: { type: :string },
+          new_password: { type: :string, example: 'newpassword123' }
+        },
+        required: %w[token new_password]
+      }
+
+      response '200', 'Password updated' do
+        let(:token) { user.generate_token_for(:password_reset) }
+        let(:reset_params) { { token: token, new_password: 'newpassword123' } }
+        run_test!
+      end
+
+      response '400', 'Invalid or expired token' do
+        let(:reset_params) { { token: 'invalid', new_password: 'newpassword123' } }
+        run_test!
+      end
+
+      response '422', 'Validation error (blank password)' do
+        let(:token) { user.generate_token_for(:password_reset) }
+        let(:reset_params) { { token: token, new_password: '' } }
+        run_test!
+      end
+
+      response '422', 'Validation error (short password)' do
+        let(:token) { user.generate_token_for(:password_reset) }
+        let(:reset_params) { { token: token, new_password: '123' } }
+        run_test!
+      end
+    end
   end
 end

--- a/api/spec/requests/api/v1/passwords_spec.rb
+++ b/api/spec/requests/api/v1/passwords_spec.rb
@@ -4,13 +4,13 @@ require 'swagger_helper'
 
 RSpec.describe 'Api::V1::Passwords', type: :request, swagger_doc: 'v1/swagger.yaml' do
   let!(:user) { create(:user) }
+  let(:valid_token) { user.generate_token_for(:password_reset) }
 
   path '/api/v1/auth/password/reset' do
-    post 'Request password reset email' do
+    post 'Password reset operations' do
       tags 'Auth'
-      description 'Sends password reset instructions to the email address provided'
       consumes 'application/json'
-      parameter name: :params, in: :body, schema: {
+      parameter name: :email, in: :body, required: false, schema: {
         type: :object,
         properties: {
           email: { type: :string, example: 'user@example.com' }
@@ -18,22 +18,7 @@ RSpec.describe 'Api::V1::Passwords', type: :request, swagger_doc: 'v1/swagger.ya
         required: ['email']
       }
 
-      response '200', 'Success message' do
-        let(:params) { { email: user.email } }
-        run_test!
-      end
-
-      response '200', 'Success message (non-existent email)' do
-        let(:params) { { email: 'unknown@example.com' } }
-        run_test!
-      end
-    end
-
-    post 'Reset password with token' do
-      tags 'Auth'
-      description 'Sets a new password using the token received'
-      consumes 'application/json'
-      parameter name: :reset_params, in: :body, schema: {
+      parameter name: :reset_params, in: :body, required: false, schema: {
         type: :object,
         properties: {
           token: { type: :string },
@@ -42,9 +27,18 @@ RSpec.describe 'Api::V1::Passwords', type: :request, swagger_doc: 'v1/swagger.ya
         required: %w[token new_password]
       }
 
-      response '200', 'Password updated' do
-        let(:token) { user.generate_token_for(:password_reset) }
-        let(:reset_params) { { token: token, new_password: 'newpassword123' } }
+      response '200', 'Reset email sent' do
+        let(:email) { { email: user.email } }
+        run_test!
+      end
+
+      response '200', 'Reset email sent (non-existent email)' do
+        let(:email) { { email: 'unknown@example.com' } }
+        run_test!
+      end
+
+      response '200', 'Password updated successfully' do
+        let(:reset_params) { { token: valid_token, new_password: 'newpassword123' } }
         run_test!
       end
 
@@ -54,14 +48,12 @@ RSpec.describe 'Api::V1::Passwords', type: :request, swagger_doc: 'v1/swagger.ya
       end
 
       response '422', 'Validation error (blank password)' do
-        let(:token) { user.generate_token_for(:password_reset) }
-        let(:reset_params) { { token: token, new_password: '' } }
+        let(:reset_params) { { token: valid_token, new_password: '' } }
         run_test!
       end
 
       response '422', 'Validation error (short password)' do
-        let(:token) { user.generate_token_for(:password_reset) }
-        let(:reset_params) { { token: token, new_password: '123' } }
+        let(:reset_params) { { token: valid_token, new_password: '123' } }
         run_test!
       end
     end

--- a/api/spec/requests/api/v1/passwords_spec.rb
+++ b/api/spec/requests/api/v1/passwords_spec.rb
@@ -13,6 +13,11 @@ RSpec.describe 'Api::V1::Passwords', type: :request, swagger_doc: 'v1/swagger.ya
       description 'Send email to request reset, or token and new_password to confirm.'
       consumes 'application/json'
 
+      parameter name: :token, in: :query, required: false, schema: {
+        type: :string,
+        description: 'Password reset token (required for confirmation flow)'
+      }
+
       parameter name: :request_body, in: :body, schema: {
         oneOf: [
           {
@@ -27,41 +32,46 @@ RSpec.describe 'Api::V1::Passwords', type: :request, swagger_doc: 'v1/swagger.ya
             type: :object,
             title: 'Password Reset Confirmation',
             properties: {
-              token: { type: :string },
               new_password: { type: :string, example: 'newpassword123' }
             },
-            required: %w[token new_password]
+            required: ['new_password']
           }
         ]
       }
 
       response '200', 'Reset email sent' do
+        let(:token) { nil }
         let(:request_body) { { email: user.email } }
         run_test!
       end
 
       response '200', 'Reset email sent (non-existent email)' do
+        let(:token) { nil }
         let(:request_body) { { email: 'unknown@example.com' } }
         run_test!
       end
 
       response '200', 'Password updated successfully' do
-        let(:request_body) { { token: valid_token, new_password: 'newpassword123' } }
+        let(:token) { valid_token }
+        let(:request_body) { { new_password: 'newpassword123' } }
         run_test!
       end
 
       response '400', 'Invalid or expired token' do
-        let(:request_body) { { token: 'invalid', new_password: 'newpassword123' } }
+        let(:token) { 'invalid' }
+        let(:request_body) { { new_password: 'newpassword123' } }
         run_test!
       end
 
       response '422', 'Validation error (blank password)' do
-        let(:request_body) { { token: valid_token, new_password: '' } }
+        let(:token) { valid_token }
+        let(:request_body) { { new_password: '' } }
         run_test!
       end
 
       response '422', 'Validation error (short password)' do
-        let(:request_body) { { token: valid_token, new_password: '123' } }
+        let(:token) { valid_token }
+        let(:request_body) { { new_password: '123' } }
         run_test!
       end
     end


### PR DESCRIPTION
This PR adds complete Rswag API documentation and test coverage for the password reset functionality. The implementation covers both stages of the password recovery flow:

1. Request password reset - User requests password reset via email
2. Reset password with token - User confirms reset with signed token

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Unified password reset flows to support both email request and token-based confirmation, with clearer success responses.
* **Bug Fixes**
  * Improved validation and distinct error feedback for invalid/expired tokens, blank passwords, and short passwords.
* **Tests**
  * Expanded specs to cover both request and confirmation flows and error responses; added mailer spec verifying reset email content and delivery.
* **Style**
  * Minor email template formatting cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->