### PR TITLE
Implement EventCategoriesService for event-category relationship management

### DIFF
--- a/web/src/services/EventCategoriesService.ts
+++ b/web/src/services/EventCategoriesService.ts
@@ -1,0 +1,35 @@
+import apiClient from '@/lib/apiClient';
+import type { Category, LinkCategoryRequest } from '@/types/category';
+
+export const EventCategoriesService = {
+  /**
+   * Retrieves all categories associated with a specific event.
+   * @param eventId The ID of the event
+   * @returns Array of categories linked to the event
+   */
+  async getEventCategories(eventId: string): Promise<Category[]> {
+    const response = await apiClient.get<Category[]>(`/api/v1/events/${eventId}/categories`);
+    return response.data;
+  },
+
+  /**
+   * Links a category to an event.
+   * @param eventId The ID of the event
+   * @param categoryId The ID of the category to link
+   * @throws Error if the category is already linked or if permission is denied
+   */
+  async linkCategoryToEvent(eventId: string, categoryId: number): Promise<void> {
+    const payload: LinkCategoryRequest = { category_id: categoryId };
+    await apiClient.post(`/api/v1/events/${eventId}/categories`, payload);
+  },
+
+  /**
+   * Unlinks a category from an event.
+   * @param eventId The ID of the event
+   * @param categoryId The ID of the category to unlink
+   * @throws Error if the category is not linked or if permission is denied
+   */
+  async unlinkCategoryFromEvent(eventId: string, categoryId: number): Promise<void> {
+    await apiClient.delete(`/api/v1/events/${eventId}/categories/${categoryId}`);
+  },
+};

--- a/web/src/test/EventCategoriesService.test.ts
+++ b/web/src/test/EventCategoriesService.test.ts
@@ -1,0 +1,164 @@
+import type { AxiosResponse } from 'axios';
+import { EventCategoriesService } from '@/services/EventCategoriesService';
+import apiClient from '@/lib/apiClient';
+import type { Category, LinkCategoryRequest } from '@/types/category';
+
+jest.mock('@/lib/apiClient', () => ({
+  __esModule: true,
+  default: {
+    get: jest.fn(),
+    post: jest.fn(),
+    delete: jest.fn(),
+  },
+}));
+
+describe('EventCategoriesService', () => {
+  const mockEventId = 'event-123';
+  const mockCategoryId = 1;
+  const mockCategory: Category = {
+    id: mockCategoryId,
+    name: 'Technology',
+    slug: 'technology',
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('getEventCategories', () => {
+    it('повинен відправляти GET-запит для отримання категорій певної події', async () => {
+      const mockCategories: Category[] = [
+        { id: 1, name: 'Technology', slug: 'technology' },
+        { id: 2, name: 'Business', slug: 'business' },
+      ];
+
+      jest.mocked(apiClient.get).mockResolvedValue({
+        data: mockCategories,
+      } as AxiosResponse);
+
+      const result = await EventCategoriesService.getEventCategories(mockEventId);
+
+      expect(apiClient.get).toHaveBeenCalledWith(`/api/v1/events/${mockEventId}/categories`);
+      expect(result).toEqual(mockCategories);
+    });
+
+    it('повинен повернути порожній масив, якщо у події немає категорій', async () => {
+      jest.mocked(apiClient.get).mockResolvedValue({
+        data: [],
+      } as AxiosResponse);
+
+      const result = await EventCategoriesService.getEventCategories(mockEventId);
+
+      expect(result).toEqual([]);
+    });
+
+    it('повинен передати помилку API при невдалому запиті', async () => {
+      const apiError = new Error('404 Not Found');
+
+      jest.mocked(apiClient.get).mockRejectedValue(apiError);
+
+      await expect(EventCategoriesService.getEventCategories(mockEventId)).rejects.toThrow(
+        '404 Not Found'
+      );
+    });
+  });
+
+  describe('linkCategoryToEvent', () => {
+    it('повинен відправляти POST-запит з правильним payload', async () => {
+      jest.mocked(apiClient.post).mockResolvedValue({
+        data: {},
+      } as AxiosResponse);
+
+      await EventCategoriesService.linkCategoryToEvent(mockEventId, mockCategoryId);
+
+      const expectedPayload: LinkCategoryRequest = { category_id: mockCategoryId };
+      expect(apiClient.post).toHaveBeenCalledWith(
+        `/api/v1/events/${mockEventId}/categories`,
+        expectedPayload
+      );
+    });
+
+    it('повинен передати помилку 409 Conflict, якщо категорія вже пов\'язана', async () => {
+      const conflictError = new Error('409 Conflict: Category already linked');
+
+      jest.mocked(apiClient.post).mockRejectedValue(conflictError);
+
+      await expect(
+        EventCategoriesService.linkCategoryToEvent(mockEventId, mockCategoryId)
+      ).rejects.toThrow('409 Conflict');
+    });
+
+    it('повинен передати помилку 403 Forbidden, якщо недостатньо дозволів', async () => {
+      const forbiddenError = new Error('403 Forbidden');
+
+      jest.mocked(apiClient.post).mockRejectedValue(forbiddenError);
+
+      await expect(
+        EventCategoriesService.linkCategoryToEvent(mockEventId, mockCategoryId)
+      ).rejects.toThrow('403 Forbidden');
+    });
+  });
+
+  describe('unlinkCategoryFromEvent', () => {
+    it('повинен відправляти DELETE-запит з правильним URL', async () => {
+      jest.mocked(apiClient.delete).mockResolvedValue({
+        data: {},
+      } as AxiosResponse);
+
+      await EventCategoriesService.unlinkCategoryFromEvent(mockEventId, mockCategoryId);
+
+      expect(apiClient.delete).toHaveBeenCalledWith(
+        `/api/v1/events/${mockEventId}/categories/${mockCategoryId}`
+      );
+    });
+
+    it('повинен передати помилку 404 Not Found, якщо категорія не пов\'язана', async () => {
+      const notFoundError = new Error('404 Not Found');
+
+      jest.mocked(apiClient.delete).mockRejectedValue(notFoundError);
+
+      await expect(
+        EventCategoriesService.unlinkCategoryFromEvent(mockEventId, mockCategoryId)
+      ).rejects.toThrow('404 Not Found');
+    });
+
+    it('повинен передати помилку 403 Forbidden, якщо недостатньо дозволів', async () => {
+      const forbiddenError = new Error('403 Forbidden');
+
+      jest.mocked(apiClient.delete).mockRejectedValue(forbiddenError);
+
+      await expect(
+        EventCategoriesService.unlinkCategoryFromEvent(mockEventId, mockCategoryId)
+      ).rejects.toThrow('403 Forbidden');
+    });
+  });
+
+  describe('Integration scenarios', () => {
+    it('повинен дозволити отримати категорії, додати нову та видалити', async () => {
+      // Сценарій: отримуємо початкові категорії
+      const initialCategories: Category[] = [mockCategory];
+      jest.mocked(apiClient.get).mockResolvedValueOnce({
+        data: initialCategories,
+      } as AxiosResponse);
+
+      const result1 = await EventCategoriesService.getEventCategories(mockEventId);
+      expect(result1).toEqual(initialCategories);
+
+      // Додаємо нову категорію
+      jest.mocked(apiClient.post).mockResolvedValueOnce({
+        data: {},
+      } as AxiosResponse);
+
+      await EventCategoriesService.linkCategoryToEvent(mockEventId, 2);
+      expect(apiClient.post).toHaveBeenCalled();
+
+      // Видаляємо категорію
+      jest.mocked(apiClient.delete).mockResolvedValueOnce({
+        data: {},
+      } as AxiosResponse);
+
+      await EventCategoriesService.unlinkCategoryFromEvent(mockEventId, mockCategoryId);
+      expect(apiClient.delete).toHaveBeenCalled();
+    });
+  });
+});

--- a/web/src/test/EventCategoriesService.test.ts
+++ b/web/src/test/EventCategoriesService.test.ts
@@ -71,14 +71,16 @@ describe('EventCategoriesService', () => {
 
       await EventCategoriesService.linkCategoryToEvent(mockEventId, mockCategoryId);
 
-      const expectedPayload: LinkCategoryRequest = { category_id: mockCategoryId };
+      const expectedPayload: LinkCategoryRequest = {
+        category_id: mockCategoryId,
+      };
       expect(apiClient.post).toHaveBeenCalledWith(
         `/api/v1/events/${mockEventId}/categories`,
         expectedPayload
       );
     });
 
-    it('повинен передати помилку 409 Conflict, якщо категорія вже пов\'язана', async () => {
+    it("повинен передати помилку 409 Conflict, якщо категорія вже пов'язана", async () => {
       const conflictError = new Error('409 Conflict: Category already linked');
 
       jest.mocked(apiClient.post).mockRejectedValue(conflictError);
@@ -112,7 +114,7 @@ describe('EventCategoriesService', () => {
       );
     });
 
-    it('повинен передати помилку 404 Not Found, якщо категорія не пов\'язана', async () => {
+    it("повинен передати помилку 404 Not Found, якщо категорія не пов'язана", async () => {
       const notFoundError = new Error('404 Not Found');
 
       jest.mocked(apiClient.delete).mockRejectedValue(notFoundError);
@@ -135,7 +137,6 @@ describe('EventCategoriesService', () => {
 
   describe('Integration scenarios', () => {
     it('повинен дозволити отримати категорії, додати нову та видалити', async () => {
-      // Сценарій: отримуємо початкові категорії
       const initialCategories: Category[] = [mockCategory];
       jest.mocked(apiClient.get).mockResolvedValueOnce({
         data: initialCategories,
@@ -144,7 +145,6 @@ describe('EventCategoriesService', () => {
       const result1 = await EventCategoriesService.getEventCategories(mockEventId);
       expect(result1).toEqual(initialCategories);
 
-      // Додаємо нову категорію
       jest.mocked(apiClient.post).mockResolvedValueOnce({
         data: {},
       } as AxiosResponse);
@@ -152,7 +152,6 @@ describe('EventCategoriesService', () => {
       await EventCategoriesService.linkCategoryToEvent(mockEventId, 2);
       expect(apiClient.post).toHaveBeenCalled();
 
-      // Видаляємо категорію
       jest.mocked(apiClient.delete).mockResolvedValueOnce({
         data: {},
       } as AxiosResponse);

--- a/web/src/types/category.ts
+++ b/web/src/types/category.ts
@@ -1,8 +1,13 @@
 export interface Category {
   id: number;
   name: string;
+  slug?: string;
 }
 
 export interface CreateCategoryRequest {
   name: string;
+}
+
+export interface LinkCategoryRequest {
+  category_id: number;
 }


### PR DESCRIPTION
Added a new EventCategoriesService to manage the many-to-many relationship between events and categories. The service provides the ability to retrieve, add, and remove categories for a specific event while respecting access permissions.

## Changes
- Created EventCategoriesService with three methods:
  * getEventCategories() - retrieves all categories associated with an event
  * linkCategoryToEvent() - adds a category to an event
  * unlinkCategoryFromEvent() - removes a category from an event

- Updated category types (category.ts):
  * Added `slug` property to Category interface
  * Added LinkCategoryRequest interface for payload typing

- Written 9 comprehensive tests:
  * GET endpoint tests (success, 404 error)
  * POST endpoint tests (success, 409 Conflict error, 403 Forbidden error)
  * DELETE endpoint tests (success, 404 error, 403 Forbidden error)
  * Integration test for complete workflow

## Technical Details
- Service uses apiClient for all requests
- JWT tokens are automatically added to headers
- Nested routing: /api/v1/events/:event_id/categories
- Error handling is delegated to apiClient
- Follows patterns from existing services (BrandMembershipsService)

## Files Changed
- web/src/services/EventCategoriesService.ts (new)
- web/src/types/category.ts (updated)
- web/src/test/EventCategoriesService.test.ts (new)