### PR TITLE
Implement TicketsService

### DIFF
--- a/web/src/services/ticketsService.ts
+++ b/web/src/services/ticketsService.ts
@@ -1,0 +1,77 @@
+
+import apiClient, { parseApiError } from '@/lib/apiClient';
+import axios from 'axios';
+import type {
+    Ticket,
+    TicketQueryParams,
+    ReviewRequest,
+    PaginatedTicketsResponse,
+    TicketFeedback
+} from '@/types/ticket';
+
+//error parser
+const handleTicketError = (err: unknown): never => {
+    if (axios.isAxiosError(err) && err.response?.data?.errors) {
+        const errors = err.response.data.errors;
+        if (typeof errors === 'object' && !Array.isArray(errors)) {
+            const messages = Object.values(errors).flat();
+            throw new Error(messages.join(', '));
+        }
+    }
+    return parseApiError(err);
+};
+
+//ticket service + feedbacks
+
+export const TicketsService = {
+    async getMyTickets(params: TicketQueryParams = {}): Promise<PaginatedTicketsResponse> {
+        try {
+            const response = await apiClient.get<PaginatedTicketsResponse>('/api/v1/tickets', { params });
+            return response.data;
+        } catch (error) {
+            return handleTicketError(error);
+        }
+    },
+
+    async createTicket(eventId: number): Promise<Ticket> {
+        try {
+            const response = await apiClient.post<Ticket>('/api/v1/tickets', {
+                ticket: { event_id: eventId },
+            });
+            return response.data;
+        } catch (error) {
+            return handleTicketError(error);
+        }
+    },
+
+    async getTicketById(id: string | number): Promise<Ticket> {
+        try {
+            const response = await apiClient.get<Ticket>(`/api/v1/tickets/${id}`);
+            return response.data;
+        } catch (error) {
+            return handleTicketError(error);
+        }
+    },
+
+    async updateTicketStatus(id: string | number, isActive: boolean): Promise<Ticket> {
+        try {
+            const response = await apiClient.patch<Ticket>(`/api/v1/tickets/${id}`, {
+                ticket: { is_active: isActive },
+            });
+            return response.data;
+        } catch (error) {
+            return handleTicketError(error);
+        }
+    },
+
+    async submitTicketReview(id: string | number, review: ReviewRequest): Promise<TicketFeedback> {
+        try {
+            const response = await apiClient.post<TicketFeedback>(`/api/v1/tickets/${id}/review`, {
+                ticket: review,
+            });
+            return response.data;
+        } catch (error) {
+            return handleTicketError(error);
+        }
+    },
+};

--- a/web/src/services/ticketsService.ts
+++ b/web/src/services/ticketsService.ts
@@ -1,77 +1,76 @@
-
 import apiClient, { parseApiError } from '@/lib/apiClient';
 import axios from 'axios';
 import type {
-    Ticket,
-    TicketQueryParams,
-    ReviewRequest,
-    PaginatedTicketsResponse,
-    TicketFeedback
+  Ticket,
+  TicketQueryParams,
+  ReviewRequest,
+  PaginatedTicketsResponse,
+  TicketFeedback,
 } from '@/types/ticket';
 
 //error parser
 const handleTicketError = (err: unknown): never => {
-    if (axios.isAxiosError(err) && err.response?.data?.errors) {
-        const errors = err.response.data.errors;
-        if (typeof errors === 'object' && !Array.isArray(errors)) {
-            const messages = Object.values(errors).flat();
-            throw new Error(messages.join(', '));
-        }
+  if (axios.isAxiosError(err) && err.response?.data?.errors) {
+    const errors = err.response.data.errors;
+    if (typeof errors === 'object' && !Array.isArray(errors)) {
+      const messages = Object.values(errors).flat();
+      throw new Error(messages.join(', '));
     }
-    return parseApiError(err);
+  }
+  return parseApiError(err);
 };
 
 //ticket service + feedbacks
 
 export const TicketsService = {
-    async getMyTickets(params: TicketQueryParams = {}): Promise<PaginatedTicketsResponse> {
-        try {
-            const response = await apiClient.get<PaginatedTicketsResponse>('/api/v1/tickets', { params });
-            return response.data;
-        } catch (error) {
-            return handleTicketError(error);
-        }
-    },
+  async getMyTickets(params: TicketQueryParams = {}): Promise<PaginatedTicketsResponse> {
+    try {
+      const response = await apiClient.get<PaginatedTicketsResponse>('/api/v1/tickets', { params });
+      return response.data;
+    } catch (error) {
+      return handleTicketError(error);
+    }
+  },
 
-    async createTicket(eventId: number): Promise<Ticket> {
-        try {
-            const response = await apiClient.post<Ticket>('/api/v1/tickets', {
-                ticket: { event_id: eventId },
-            });
-            return response.data;
-        } catch (error) {
-            return handleTicketError(error);
-        }
-    },
+  async createTicket(eventId: number): Promise<Ticket> {
+    try {
+      const response = await apiClient.post<Ticket>('/api/v1/tickets', {
+        ticket: { event_id: eventId },
+      });
+      return response.data;
+    } catch (error) {
+      return handleTicketError(error);
+    }
+  },
 
-    async getTicketById(id: string | number): Promise<Ticket> {
-        try {
-            const response = await apiClient.get<Ticket>(`/api/v1/tickets/${id}`);
-            return response.data;
-        } catch (error) {
-            return handleTicketError(error);
-        }
-    },
+  async getTicketById(id: string | number): Promise<Ticket> {
+    try {
+      const response = await apiClient.get<Ticket>(`/api/v1/tickets/${id}`);
+      return response.data;
+    } catch (error) {
+      return handleTicketError(error);
+    }
+  },
 
-    async updateTicketStatus(id: string | number, isActive: boolean): Promise<Ticket> {
-        try {
-            const response = await apiClient.patch<Ticket>(`/api/v1/tickets/${id}`, {
-                ticket: { is_active: isActive },
-            });
-            return response.data;
-        } catch (error) {
-            return handleTicketError(error);
-        }
-    },
+  async updateTicketStatus(id: string | number, isActive: boolean): Promise<Ticket> {
+    try {
+      const response = await apiClient.patch<Ticket>(`/api/v1/tickets/${id}`, {
+        ticket: { is_active: isActive },
+      });
+      return response.data;
+    } catch (error) {
+      return handleTicketError(error);
+    }
+  },
 
-    async submitTicketReview(id: string | number, review: ReviewRequest): Promise<TicketFeedback> {
-        try {
-            const response = await apiClient.post<TicketFeedback>(`/api/v1/tickets/${id}/review`, {
-                ticket: review,
-            });
-            return response.data;
-        } catch (error) {
-            return handleTicketError(error);
-        }
-    },
+  async submitTicketReview(id: string | number, review: ReviewRequest): Promise<TicketFeedback> {
+    try {
+      const response = await apiClient.post<TicketFeedback>(`/api/v1/tickets/${id}/review`, {
+        ticket: review,
+      });
+      return response.data;
+    } catch (error) {
+      return handleTicketError(error);
+    }
+  },
 };

--- a/web/src/test/ticketsService.test.ts
+++ b/web/src/test/ticketsService.test.ts
@@ -1,22 +1,23 @@
-
 import apiClient from '@/lib/apiClient';
 import { TicketsService } from '@/services/ticketsService';
 import type {
-    Ticket,
-    TicketQueryParams,
-    PaginatedTicketsResponse,
-    ReviewRequest,
-    TicketFeedback
+  Ticket,
+  TicketQueryParams,
+  PaginatedTicketsResponse,
+  ReviewRequest,
+  TicketFeedback,
 } from '@/types/ticket';
 
 jest.mock('@/lib/apiClient', () => ({
-    __esModule: true,
-    default: {
-        get: jest.fn(),
-        post: jest.fn(),
-        patch: jest.fn(),
-    },
-    parseApiError: jest.fn((err) => { throw err; })
+  __esModule: true,
+  default: {
+    get: jest.fn(),
+    post: jest.fn(),
+    patch: jest.fn(),
+  },
+  parseApiError: jest.fn((err) => {
+    throw err;
+  }),
 }));
 
 const mockedGet = apiClient.get as jest.Mock;
@@ -24,89 +25,89 @@ const mockedPost = apiClient.post as jest.Mock;
 const mockedPatch = apiClient.patch as jest.Mock;
 
 const mockTicket: Ticket = {
-    id: '123',
-    is_active: true,
-    qr_code_url: 'https://example.com/qr.png',
-    event_id: 1,
-    user_id: 42,
-    event: {
-        id: 1,
-        title: 'Tech Summit 2026',
-        location: 'Kyiv',
-        start_date: '2026-05-14T09:00:00.000Z',
-        end_date: '2026-05-14T18:00:00.000Z'
-    }
+  id: '123',
+  is_active: true,
+  qr_code_url: 'https://example.com/qr.png',
+  event_id: 1,
+  user_id: 42,
+  event: {
+    id: 1,
+    title: 'Tech Summit 2026',
+    location: 'Kyiv',
+    start_date: '2026-05-14T09:00:00.000Z',
+    end_date: '2026-05-14T18:00:00.000Z',
+  },
 };
 
 const mockFeedback: TicketFeedback = {
-    id: 10,
-    rating: 5,
-    comment: 'Great event!'
+  id: 10,
+  rating: 5,
+  comment: 'Great event!',
 };
 
 const mockPaginatedResponse: PaginatedTicketsResponse = {
-    data: [mockTicket],
-    meta: { page: 1, per_page: 20, total: 1 },
+  data: [mockTicket],
+  meta: { page: 1, per_page: 20, total: 1 },
 };
 
 describe('TicketsService', () => {
-    beforeEach(() => {
-        jest.clearAllMocks();
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('Ticket Management', () => {
+    it('getMyTickets: fetches tickets with query params', async () => {
+      mockedGet.mockResolvedValueOnce({ data: mockPaginatedResponse });
+      const params: TicketQueryParams = { page: 1, is_active: true };
+
+      const result = await TicketsService.getMyTickets(params);
+
+      expect(mockedGet).toHaveBeenCalledWith('/api/v1/tickets', { params });
+      expect(result).toEqual(mockPaginatedResponse);
     });
 
-    describe('Ticket Management', () => {
-        it('getMyTickets: fetches tickets with query params', async () => {
-            mockedGet.mockResolvedValueOnce({ data: mockPaginatedResponse });
-            const params: TicketQueryParams = { page: 1, is_active: true };
+    it('getTicketById: fetches a single ticket', async () => {
+      mockedGet.mockResolvedValueOnce({ data: mockTicket });
 
-            const result = await TicketsService.getMyTickets(params);
+      const result = await TicketsService.getTicketById('123');
 
-            expect(mockedGet).toHaveBeenCalledWith('/api/v1/tickets', { params });
-            expect(result).toEqual(mockPaginatedResponse);
-        });
-
-        it('getTicketById: fetches a single ticket', async () => {
-            mockedGet.mockResolvedValueOnce({ data: mockTicket });
-
-            const result = await TicketsService.getTicketById('123');
-
-            expect(mockedGet).toHaveBeenCalledWith('/api/v1/tickets/123');
-            expect(result.id).toBe('123');
-        });
-
-        it('createTicket: sends event_id nested in ticket object', async () => {
-            mockedPost.mockResolvedValueOnce({ data: mockTicket });
-
-            await TicketsService.createTicket(1);
-
-            expect(mockedPost).toHaveBeenCalledWith('/api/v1/tickets', {
-                ticket: { event_id: 1 }
-            });
-        });
+      expect(mockedGet).toHaveBeenCalledWith('/api/v1/tickets/123');
+      expect(result.id).toBe('123');
     });
 
-    describe('Status & Feedback', () => {
-        it('updateTicketStatus: sends is_active nested in ticket object', async () => {
-            mockedPatch.mockResolvedValueOnce({ data: { ...mockTicket, is_active: false } });
+    it('createTicket: sends event_id nested in ticket object', async () => {
+      mockedPost.mockResolvedValueOnce({ data: mockTicket });
 
-            const result = await TicketsService.updateTicketStatus('123', false);
+      await TicketsService.createTicket(1);
 
-            expect(mockedPatch).toHaveBeenCalledWith('/api/v1/tickets/123', {
-                ticket: { is_active: false }
-            });
-            expect(result.is_active).toBe(false);
-        });
-
-        it('submitTicketReview: sends rating and comment nested in ticket object', async () => {
-            mockedPost.mockResolvedValueOnce({ data: mockFeedback });
-            const review: ReviewRequest = { rating: 5, comment: 'Awesome!' };
-
-            const result = await TicketsService.submitTicketReview('123', review);
-
-            expect(mockedPost).toHaveBeenCalledWith('/api/v1/tickets/123/review', {
-                ticket: review
-            });
-            expect(result.rating).toBe(5);
-        });
+      expect(mockedPost).toHaveBeenCalledWith('/api/v1/tickets', {
+        ticket: { event_id: 1 },
+      });
     });
+  });
+
+  describe('Status & Feedback', () => {
+    it('updateTicketStatus: sends is_active nested in ticket object', async () => {
+      mockedPatch.mockResolvedValueOnce({ data: { ...mockTicket, is_active: false } });
+
+      const result = await TicketsService.updateTicketStatus('123', false);
+
+      expect(mockedPatch).toHaveBeenCalledWith('/api/v1/tickets/123', {
+        ticket: { is_active: false },
+      });
+      expect(result.is_active).toBe(false);
+    });
+
+    it('submitTicketReview: sends rating and comment nested in ticket object', async () => {
+      mockedPost.mockResolvedValueOnce({ data: mockFeedback });
+      const review: ReviewRequest = { rating: 5, comment: 'Awesome!' };
+
+      const result = await TicketsService.submitTicketReview('123', review);
+
+      expect(mockedPost).toHaveBeenCalledWith('/api/v1/tickets/123/review', {
+        ticket: review,
+      });
+      expect(result.rating).toBe(5);
+    });
+  });
 });

--- a/web/src/test/ticketsService.test.ts
+++ b/web/src/test/ticketsService.test.ts
@@ -1,0 +1,112 @@
+
+import apiClient from '@/lib/apiClient';
+import { TicketsService } from '@/services/ticketsService';
+import type {
+    Ticket,
+    TicketQueryParams,
+    PaginatedTicketsResponse,
+    ReviewRequest,
+    TicketFeedback
+} from '@/types/ticket';
+
+jest.mock('@/lib/apiClient', () => ({
+    __esModule: true,
+    default: {
+        get: jest.fn(),
+        post: jest.fn(),
+        patch: jest.fn(),
+    },
+    parseApiError: jest.fn((err) => { throw err; })
+}));
+
+const mockedGet = apiClient.get as jest.Mock;
+const mockedPost = apiClient.post as jest.Mock;
+const mockedPatch = apiClient.patch as jest.Mock;
+
+const mockTicket: Ticket = {
+    id: '123',
+    is_active: true,
+    qr_code_url: 'https://example.com/qr.png',
+    event_id: 1,
+    user_id: 42,
+    event: {
+        id: 1,
+        title: 'Tech Summit 2026',
+        location: 'Kyiv',
+        start_date: '2026-05-14T09:00:00.000Z',
+        end_date: '2026-05-14T18:00:00.000Z'
+    }
+};
+
+const mockFeedback: TicketFeedback = {
+    id: 10,
+    rating: 5,
+    comment: 'Great event!'
+};
+
+const mockPaginatedResponse: PaginatedTicketsResponse = {
+    data: [mockTicket],
+    meta: { page: 1, per_page: 20, total: 1 },
+};
+
+describe('TicketsService', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    describe('Ticket Management', () => {
+        it('getMyTickets: fetches tickets with query params', async () => {
+            mockedGet.mockResolvedValueOnce({ data: mockPaginatedResponse });
+            const params: TicketQueryParams = { page: 1, is_active: true };
+
+            const result = await TicketsService.getMyTickets(params);
+
+            expect(mockedGet).toHaveBeenCalledWith('/api/v1/tickets', { params });
+            expect(result).toEqual(mockPaginatedResponse);
+        });
+
+        it('getTicketById: fetches a single ticket', async () => {
+            mockedGet.mockResolvedValueOnce({ data: mockTicket });
+
+            const result = await TicketsService.getTicketById('123');
+
+            expect(mockedGet).toHaveBeenCalledWith('/api/v1/tickets/123');
+            expect(result.id).toBe('123');
+        });
+
+        it('createTicket: sends event_id nested in ticket object', async () => {
+            mockedPost.mockResolvedValueOnce({ data: mockTicket });
+
+            await TicketsService.createTicket(1);
+
+            expect(mockedPost).toHaveBeenCalledWith('/api/v1/tickets', {
+                ticket: { event_id: 1 }
+            });
+        });
+    });
+
+    describe('Status & Feedback', () => {
+        it('updateTicketStatus: sends is_active nested in ticket object', async () => {
+            mockedPatch.mockResolvedValueOnce({ data: { ...mockTicket, is_active: false } });
+
+            const result = await TicketsService.updateTicketStatus('123', false);
+
+            expect(mockedPatch).toHaveBeenCalledWith('/api/v1/tickets/123', {
+                ticket: { is_active: false }
+            });
+            expect(result.is_active).toBe(false);
+        });
+
+        it('submitTicketReview: sends rating and comment nested in ticket object', async () => {
+            mockedPost.mockResolvedValueOnce({ data: mockFeedback });
+            const review: ReviewRequest = { rating: 5, comment: 'Awesome!' };
+
+            const result = await TicketsService.submitTicketReview('123', review);
+
+            expect(mockedPost).toHaveBeenCalledWith('/api/v1/tickets/123/review', {
+                ticket: review
+            });
+            expect(result.rating).toBe(5);
+        });
+    });
+});

--- a/web/src/types/ticket.ts
+++ b/web/src/types/ticket.ts
@@ -1,0 +1,51 @@
+export type SortOrder = 'asc' | 'desc';
+
+export interface TicketEvent {
+    id: number;
+    title: string;
+    location: string;
+    start_date: string;
+    end_date: string | null;
+}
+
+export interface TicketFeedback {
+    id: number;
+    rating: number;
+    comment: string;
+}
+
+export interface Ticket {
+    id: string;
+    is_active: boolean;
+    qr_code_url?: string;
+    event_id: number;
+    user_id: number;
+    event?: TicketEvent;
+    event_feedback?: TicketFeedback;
+}
+
+export interface TicketQueryParams {
+    page?: number;
+    per_page?: number;
+    sort?: string;
+    order?: SortOrder;
+    q?: string;
+    is_active?: boolean;
+    event_id?: number;
+}
+
+export interface ReviewRequest {
+    rating: number;
+    comment: string;
+}
+
+export interface PaginationMeta {
+    page: number;
+    per_page: number;
+    total: number;
+}
+
+export interface PaginatedTicketsResponse {
+    data: Ticket[];
+    meta: PaginationMeta;
+}

--- a/web/src/types/ticket.ts
+++ b/web/src/types/ticket.ts
@@ -1,51 +1,51 @@
 export type SortOrder = 'asc' | 'desc';
 
 export interface TicketEvent {
-    id: number;
-    title: string;
-    location: string;
-    start_date: string;
-    end_date: string | null;
+  id: number;
+  title: string;
+  location: string;
+  start_date: string;
+  end_date: string | null;
 }
 
 export interface TicketFeedback {
-    id: number;
-    rating: number;
-    comment: string;
+  id: number;
+  rating: number;
+  comment: string;
 }
 
 export interface Ticket {
-    id: string;
-    is_active: boolean;
-    qr_code_url?: string;
-    event_id: number;
-    user_id: number;
-    event?: TicketEvent;
-    event_feedback?: TicketFeedback;
+  id: string;
+  is_active: boolean;
+  qr_code_url?: string;
+  event_id: number;
+  user_id: number;
+  event?: TicketEvent;
+  event_feedback?: TicketFeedback;
 }
 
 export interface TicketQueryParams {
-    page?: number;
-    per_page?: number;
-    sort?: string;
-    order?: SortOrder;
-    q?: string;
-    is_active?: boolean;
-    event_id?: number;
+  page?: number;
+  per_page?: number;
+  sort?: string;
+  order?: SortOrder;
+  q?: string;
+  is_active?: boolean;
+  event_id?: number;
 }
 
 export interface ReviewRequest {
-    rating: number;
-    comment: string;
+  rating: number;
+  comment: string;
 }
 
 export interface PaginationMeta {
-    page: number;
-    per_page: number;
-    total: number;
+  page: number;
+  per_page: number;
+  total: number;
 }
 
 export interface PaginatedTicketsResponse {
-    data: Ticket[];
-    meta: PaginationMeta;
+  data: Ticket[];
+  meta: PaginationMeta;
 }


### PR DESCRIPTION
Implemented `TicketsService` for ticket management and reviews. All acceptance criteria are met:

- Added data contracts (`ticket.types.ts`).
- Created service methods with required nested `{ ticket: { ... } }` payloads and JWT injection via `apiClient`.
- Mapped all 7 query parameters for `getMyTickets`.
- Added a local error parser to safely handle non-standard Rails validation errors.
- Covered all methods with unit tests (passing).