### PR TITLE
Implement EventLifecycleService and refactor transitions

### DIFF
--- a/web/src/services/event-lifecycle-service.ts
+++ b/web/src/services/event-lifecycle-service.ts
@@ -4,46 +4,46 @@ import axios from 'axios';
 import type { Event } from '@/types/event';
 
 const handleLifecycleError = (err: unknown): never => {
-  if (axios.isAxiosError(err) && err.response?.data?.message) {
-    throw new Error(err.response.data.message);
-  }
-  return parseApiError(err);
+    if (axios.isAxiosError(err) && err.response?.data?.message) {
+        throw new Error(err.response.data.message);
+    }
+    return parseApiError(err);
 };
 
 export const EventLifecycleService = {
-  async submitEvent(id: string | number): Promise<Event> {
-    try {
-      const response = await apiClient.post(`/api/v1/events/${id}/submit`);
-      return response.data.data || response.data;
-    } catch (error) {
-      return handleLifecycleError(error);
-    }
-  },
+    async submitEvent(id: string | number): Promise<Event> {
+        try {
+            const response = await apiClient.post(`/api/v1/events/${id}/submit`);
+            return response.data.data ?? response.data;
+        } catch (error) {
+            return handleLifecycleError(error);
+        }
+    },
 
-  async approveEvent(id: string | number): Promise<Event> {
-    try {
-      const response = await apiClient.post(`/api/v1/events/${id}/approve`);
-      return response.data.data || response.data;
-    } catch (error) {
-      return handleLifecycleError(error);
-    }
-  },
+    async approveEvent(id: string | number): Promise<Event> {
+        try {
+            const response = await apiClient.post(`/api/v1/events/${id}/approve`);
+            return response.data.data ?? response.data;
+        } catch (error) {
+            return handleLifecycleError(error);
+        }
+    },
 
-  async rejectEvent(id: string | number, payload: { reason?: string } = {}): Promise<Event> {
-    try {
-      const response = await apiClient.post(`/api/v1/events/${id}/reject`, payload);
-      return response.data.data || response.data;
-    } catch (error) {
-      return handleLifecycleError(error);
-    }
-  },
+    async rejectEvent(id: string | number, payload: { reason?: string } = {}): Promise<Event> {
+        try {
+            const response = await apiClient.post(`/api/v1/events/${id}/reject`, payload);
+            return response.data.data ?? response.data;
+        } catch (error) {
+            return handleLifecycleError(error);
+        }
+    },
 
-  async cancelEvent(id: string | number): Promise<Event> {
-    try {
-      const response = await apiClient.post(`/api/v1/events/${id}/cancel`);
-      return response.data.data || response.data;
-    } catch (error) {
-      return handleLifecycleError(error);
-    }
-  },
+    async cancelEvent(id: string | number): Promise<Event> {
+        try {
+            const response = await apiClient.post(`/api/v1/events/${id}/cancel`);
+            return response.data.data ?? response.data;
+        } catch (error) {
+            return handleLifecycleError(error);
+        }
+    },
 };

--- a/web/src/services/event-lifecycle-service.ts
+++ b/web/src/services/event-lifecycle-service.ts
@@ -4,46 +4,46 @@ import axios from 'axios';
 import type { Event } from '@/types/event';
 
 const handleLifecycleError = (err: unknown): never => {
-    if (axios.isAxiosError(err) && err.response?.data?.message) {
-        throw new Error(err.response.data.message);
-    }
-    return parseApiError(err);
+  if (axios.isAxiosError(err) && err.response?.data?.message) {
+    throw new Error(err.response.data.message);
+  }
+  return parseApiError(err);
 };
 
 export const EventLifecycleService = {
-    async submitEvent(id: string | number): Promise<Event> {
-        try {
-            const response = await apiClient.post(`/api/v1/events/${id}/submit`);
-            return response.data.data ?? response.data;
-        } catch (error) {
-            return handleLifecycleError(error);
-        }
-    },
+  async submitEvent(id: string | number): Promise<Event> {
+    try {
+      const response = await apiClient.post(`/api/v1/events/${id}/submit`);
+      return response.data.data ?? response.data;
+    } catch (error) {
+      return handleLifecycleError(error);
+    }
+  },
 
-    async approveEvent(id: string | number): Promise<Event> {
-        try {
-            const response = await apiClient.post(`/api/v1/events/${id}/approve`);
-            return response.data.data ?? response.data;
-        } catch (error) {
-            return handleLifecycleError(error);
-        }
-    },
+  async approveEvent(id: string | number): Promise<Event> {
+    try {
+      const response = await apiClient.post(`/api/v1/events/${id}/approve`);
+      return response.data.data ?? response.data;
+    } catch (error) {
+      return handleLifecycleError(error);
+    }
+  },
 
-    async rejectEvent(id: string | number, payload: { reason?: string } = {}): Promise<Event> {
-        try {
-            const response = await apiClient.post(`/api/v1/events/${id}/reject`, payload);
-            return response.data.data ?? response.data;
-        } catch (error) {
-            return handleLifecycleError(error);
-        }
-    },
+  async rejectEvent(id: string | number, payload: { reason?: string } = {}): Promise<Event> {
+    try {
+      const response = await apiClient.post(`/api/v1/events/${id}/reject`, payload);
+      return response.data.data ?? response.data;
+    } catch (error) {
+      return handleLifecycleError(error);
+    }
+  },
 
-    async cancelEvent(id: string | number): Promise<Event> {
-        try {
-            const response = await apiClient.post(`/api/v1/events/${id}/cancel`);
-            return response.data.data ?? response.data;
-        } catch (error) {
-            return handleLifecycleError(error);
-        }
-    },
+  async cancelEvent(id: string | number): Promise<Event> {
+    try {
+      const response = await apiClient.post(`/api/v1/events/${id}/cancel`);
+      return response.data.data ?? response.data;
+    } catch (error) {
+      return handleLifecycleError(error);
+    }
+  },
 };

--- a/web/src/services/event-lifecycle-service.ts
+++ b/web/src/services/event-lifecycle-service.ts
@@ -1,0 +1,49 @@
+import apiClient from '@/lib/api-client';
+import { parseApiError } from '@/lib/api-client';
+import axios from 'axios';
+import type { Event } from '@/types/event';
+
+const handleLifecycleError = (err: unknown): never => {
+  if (axios.isAxiosError(err) && err.response?.data?.message) {
+    throw new Error(err.response.data.message);
+  }
+  return parseApiError(err);
+};
+
+export const EventLifecycleService = {
+  async submitEvent(id: string | number): Promise<Event> {
+    try {
+      const response = await apiClient.post(`/api/v1/events/${id}/submit`);
+      return response.data.data || response.data;
+    } catch (error) {
+      return handleLifecycleError(error);
+    }
+  },
+
+  async approveEvent(id: string | number): Promise<Event> {
+    try {
+      const response = await apiClient.post(`/api/v1/events/${id}/approve`);
+      return response.data.data || response.data;
+    } catch (error) {
+      return handleLifecycleError(error);
+    }
+  },
+
+  async rejectEvent(id: string | number, payload: { reason?: string } = {}): Promise<Event> {
+    try {
+      const response = await apiClient.post(`/api/v1/events/${id}/reject`, payload);
+      return response.data.data || response.data;
+    } catch (error) {
+      return handleLifecycleError(error);
+    }
+  },
+
+  async cancelEvent(id: string | number): Promise<Event> {
+    try {
+      const response = await apiClient.post(`/api/v1/events/${id}/cancel`);
+      return response.data.data || response.data;
+    } catch (error) {
+      return handleLifecycleError(error);
+    }
+  },
+};

--- a/web/src/services/events-service.ts
+++ b/web/src/services/events-service.ts
@@ -22,24 +22,4 @@ export const EventsService = {
     const response = await apiClient.post('/api/v1/events', { event: payload });
     return response.data.data;
   },
-
-  async submitEvent(id: number): Promise<Event> {
-    const response = await apiClient.post(`/api/v1/events/${id}/submit`);
-    return response.data.data;
-  },
-
-  async approveEvent(id: number): Promise<Event> {
-    const response = await apiClient.post(`/api/v1/events/${id}/approve`);
-    return response.data.data;
-  },
-
-  async rejectEvent(id: number, payload: { reason?: string } = {}): Promise<Event> {
-    const response = await apiClient.post(`/api/v1/events/${id}/reject`, payload);
-    return response.data.data;
-  },
-
-  async cancelEvent(id: number): Promise<Event> {
-    const response = await apiClient.post(`/api/v1/events/${id}/cancel`);
-    return response.data.data;
-  },
 };

--- a/web/src/services/superadmin-service.ts
+++ b/web/src/services/superadmin-service.ts
@@ -12,16 +12,6 @@ export const SuperadminService = {
     return response.data;
   },
 
-  async approveEvent(eventId: string | number) {
-    const response = await apiClient.post(`/api/v1/events/${eventId}/approve`);
-    return response.data;
-  },
-
-  async rejectEvent(eventId: string | number) {
-    const response = await apiClient.post(`/api/v1/events/${eventId}/reject`);
-    return response.data;
-  },
-
   async updateUser(userId: string | number, payload: UpdateUserPayload) {
     const response = await apiClient.patch(`/api/v1/users/${userId}`, payload);
     return response.data;

--- a/web/src/test/event-lifecycle-service.test.ts
+++ b/web/src/test/event-lifecycle-service.test.ts
@@ -82,8 +82,8 @@ describe('EventLifecycleService', () => {
       const mockAxiosError = {
         isAxiosError: true,
         response: {
-          data: { message: specificMessage }
-        }
+          data: { message: specificMessage },
+        },
       };
 
       mockedPost.mockRejectedValueOnce(mockAxiosError);

--- a/web/src/test/event-lifecycle-service.test.ts
+++ b/web/src/test/event-lifecycle-service.test.ts
@@ -1,0 +1,78 @@
+import apiClient from '@/lib/api-client';
+import { EventLifecycleService } from '@/services/event-lifecycle-service';
+import type { Event } from '@/types/event';
+
+jest.mock('@/lib/api-client', () => ({
+  __esModule: true,
+  default: {
+    post: jest.fn(),
+  },
+  parseApiError: jest.fn((err) => {
+    throw err;
+  }),
+}));
+
+const mockedPost = apiClient.post as jest.Mock;
+
+const mockEvent: Event = {
+  id: 1,
+  title: 'Tech Summit 2026',
+  start_date: '2026-09-01T09:00:00.000Z',
+  status: 'draft',
+  brand_id: 42,
+};
+
+describe('EventLifecycleService', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('Submission & Review', () => {
+    it('submitEvent: should call submit endpoint and return event', async () => {
+      mockedPost.mockResolvedValueOnce({
+        data: { data: { ...mockEvent, status: 'draft_on_review' } },
+      });
+
+      const result = await EventLifecycleService.submitEvent(1);
+
+      expect(mockedPost).toHaveBeenCalledWith('/api/v1/events/1/submit');
+      expect(result.status).toBe('draft_on_review');
+    });
+
+    it('approveEvent: should call approve endpoint and return published event', async () => {
+      mockedPost.mockResolvedValueOnce({
+        data: { data: { ...mockEvent, status: 'published' } },
+      });
+
+      const result = await EventLifecycleService.approveEvent(1);
+
+      expect(mockedPost).toHaveBeenCalledWith('/api/v1/events/1/approve');
+      expect(result.status).toBe('published');
+    });
+
+    it('rejectEvent: should call reject endpoint with reason and return rejected event', async () => {
+      mockedPost.mockResolvedValueOnce({
+        data: { data: { ...mockEvent, status: 'rejected' } },
+      });
+      const payload = { reason: 'Incomplete details' };
+
+      const result = await EventLifecycleService.rejectEvent(1, payload);
+
+      expect(mockedPost).toHaveBeenCalledWith('/api/v1/events/1/reject', payload);
+      expect(result.status).toBe('rejected');
+    });
+  });
+
+  describe('Termination', () => {
+    it('cancelEvent: should call cancel endpoint and return cancelled event', async () => {
+      mockedPost.mockResolvedValueOnce({
+        data: { data: { ...mockEvent, status: 'cancelled' } },
+      });
+
+      const result = await EventLifecycleService.cancelEvent(1);
+
+      expect(mockedPost).toHaveBeenCalledWith('/api/v1/events/1/cancel');
+      expect(result.status).toBe('cancelled');
+    });
+  });
+});

--- a/web/src/test/event-lifecycle-service.test.ts
+++ b/web/src/test/event-lifecycle-service.test.ts
@@ -1,4 +1,4 @@
-import apiClient from '@/lib/api-client';
+import apiClient, { parseApiError } from '@/lib/api-client';
 import { EventLifecycleService } from '@/services/event-lifecycle-service';
 import type { Event } from '@/types/event';
 
@@ -73,6 +73,31 @@ describe('EventLifecycleService', () => {
 
       expect(mockedPost).toHaveBeenCalledWith('/api/v1/events/1/cancel');
       expect(result.status).toBe('cancelled');
+    });
+  });
+
+  describe('Error Handling (handleLifecycleError)', () => {
+    it('Branch 1: throws specific message if Axios error contains response.data.message (422/403)', async () => {
+      const specificMessage = 'All required fields must be filled before submission';
+      const mockAxiosError = {
+        isAxiosError: true,
+        response: {
+          data: { message: specificMessage }
+        }
+      };
+
+      mockedPost.mockRejectedValueOnce(mockAxiosError);
+
+      await expect(EventLifecycleService.submitEvent(1)).rejects.toThrow(specificMessage);
+    });
+
+    it('Branch 2: fallbacks to parseApiError for non-Axios or standard errors', async () => {
+      const standardError = new Error('Network down');
+      mockedPost.mockRejectedValueOnce(standardError);
+
+      await expect(EventLifecycleService.submitEvent(1)).rejects.toThrow();
+
+      expect(parseApiError).toHaveBeenCalledWith(standardError);
     });
   });
 });

--- a/web/src/test/events-service.test.ts
+++ b/web/src/test/events-service.test.ts
@@ -107,59 +107,6 @@ describe('EventsService', () => {
     });
   });
 
-  describe('Management Methods (Transitions)', () => {
-    it('submitEvent: should call submit endpoint and return draft_on_review status', async () => {
-      mockedPost.mockResolvedValueOnce({
-        data: { data: { ...mockEvent, status: 'draft_on_review' } },
-      });
-
-      const result = await EventsService.submitEvent(1);
-
-      expect(mockedPost).toHaveBeenCalledWith('/api/v1/events/1/submit');
-      expect(result.status).toBe('draft_on_review');
-    });
-
-    it('rejectEvent: should call reject endpoint with reason', async () => {
-      mockedPost.mockResolvedValueOnce({ data: { data: { ...mockEvent, status: 'rejected' } } });
-      const payload = { reason: 'Invalid data' };
-
-      const result = await EventsService.rejectEvent(1, payload);
-
-      expect(mockedPost).toHaveBeenCalledWith('/api/v1/events/1/reject', payload);
-      expect(result.status).toBe('rejected');
-    });
-
-    // --- НОВІ ТЕСТИ ---
-
-    it('approveEvent: should call approve endpoint and return published status', async () => {
-      // Налаштовуємо мок на повернення статусу 'published'
-      mockedPost.mockResolvedValueOnce({
-        data: { data: { ...mockEvent, status: 'published' } },
-      });
-
-      const result = await EventsService.approveEvent(1);
-
-      // Перевіряємо правильність URL
-      expect(mockedPost).toHaveBeenCalledWith('/api/v1/events/1/approve');
-      // Перевіряємо, чи статус оброблено правильно
-      expect(result.status).toBe('published');
-    });
-
-    it('cancelEvent: should call cancel endpoint and return cancelled status', async () => {
-      // Налаштовуємо мок на повернення статусу 'cancelled'
-      mockedPost.mockResolvedValueOnce({
-        data: { data: { ...mockEvent, status: 'cancelled' } },
-      });
-
-      const result = await EventsService.cancelEvent(1);
-
-      // Перевіряємо правильність URL
-      expect(mockedPost).toHaveBeenCalledWith('/api/v1/events/1/cancel');
-      // Перевіряємо, чи статус оброблено правильно
-      expect(result.status).toBe('cancelled');
-    });
-  });
-
   describe('Creation', () => {
     it('should create an event with correct payload structure', async () => {
       const payload: CreateEventRequest = {

--- a/web/src/test/superadmin-service.test.ts
+++ b/web/src/test/superadmin-service.test.ts
@@ -26,30 +26,6 @@ describe('SuperadminService', () => {
       expect(JSON.parse(mock.history.post[0].data)).toEqual(payload);
       expect(result).toEqual(responseData);
     });
-
-    it('approveEvent sends POST request to /api/v1/events/:id/approve', async () => {
-      const eventId = 123;
-      const responseData = { success: true };
-
-      mock.onPost(`/api/v1/events/${eventId}/approve`).reply(200, responseData);
-
-      const result = await SuperadminService.approveEvent(eventId);
-
-      expect(mock.history.post[0].url).toBe(`/api/v1/events/${eventId}/approve`);
-      expect(result).toEqual(responseData);
-    });
-
-    it('rejectEvent sends POST request to /api/v1/events/:id/reject', async () => {
-      const eventId = 123;
-      const responseData = { success: true };
-
-      mock.onPost(`/api/v1/events/${eventId}/reject`).reply(200, responseData);
-
-      const result = await SuperadminService.rejectEvent(eventId);
-
-      expect(mock.history.post[0].url).toBe(`/api/v1/events/${eventId}/reject`);
-      expect(result).toEqual(responseData);
-    });
   });
 
   describe('Users', () => {


### PR DESCRIPTION
Implemented `EventLifecycleService` to centralize the state machine transitions (`submit`, `approve`, `reject`, `cancel`) and cleanly interface with the backend's AASM logic. 

**Key Changes:**
- **New Service:** Created `EventLifecycleService` handling action-based POST endpoints.
- **Error Handling:** Added `handleLifecycleError` to specifically catch and display detailed 422 (Unprocessable Entity) and 403 (Forbidden) messages from Rails.
- **Refactoring (DRY):** Removed duplicated transition methods from `EventsService` and `SuperadminService` to enforce the Single Responsibility Principle.
- **Testing:** Extracted and updated transition unit tests into a dedicated `eventLifecycleService.test.ts` file.

**Acceptance Criteria Met:**
- [x] Service maps to all four transition endpoints.
- [x] Correct typing (`Promise<Event>`) for state synchronization.
- [x] Uses `apiClient` for JWT enforcement.
- [x] Gracefully handles pre-condition validation errors (422) and role restrictions (403).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized event lifecycle operations (submit, approve, reject, cancel) into a dedicated service module
  * Updated existing services to remove these methods from their exports
  * Consolidated related functionality for improved code organization

* **Tests**
  * Added comprehensive test suite for the new service module
  * Updated existing test suites to reflect architectural changes

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/UA-5381-Ruby/EventifyMTEP/pull/97?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->