### PR TITLE
Move location coordinates fetching to MapService and add tests

### DIFF
--- a/web/.env.example
+++ b/web/.env.example
@@ -1,1 +1,2 @@
 VITE_API_BASE_URL=http://localhost:3000
+VITE_MAP_API_BASE_URL=

--- a/web/src/components/events/event-location.tsx
+++ b/web/src/components/events/event-location.tsx
@@ -7,6 +7,8 @@ import L from 'leaflet';
 import icon from 'leaflet/dist/images/marker-icon.png';
 import iconShadow from 'leaflet/dist/images/marker-shadow.png';
 
+import { MapService } from '@/services/map-service';
+
 const DefaultIcon = L.icon({
   iconUrl: icon,
   shadowUrl: iconShadow,
@@ -28,27 +30,15 @@ export function EventLocationSection({ location }: EventLocationSectionProps) {
   useEffect(() => {
     if (isOnline || !location) return;
 
-    const fetchCoordinates = async () => {
-      try {
-        // OpenStreetMap's free Nominatim Geocoding API
-        const response = await fetch(
-          `https://nominatim.openstreetmap.org/search?format=json&q=${encodeURIComponent(location)}`
-        );
-        const data = await response.json();
-
-        if (data && data.length > 0) {
-          setCoords([parseFloat(data[0].lat), parseFloat(data[0].lon)]);
-          setError(false);
-        } else {
-          setError(true);
-        }
-      } catch (err) {
+    MapService.getCoordinates(location)
+      .then(({ lat, lon }) => {
+        setCoords([lat, lon]);
+        setError(false);
+      })
+      .catch((err) => {
         console.error('Error fetching coordinates:', err);
         setError(true);
-      }
-    };
-
-    fetchCoordinates();
+      });
   }, [location, isOnline]);
 
   return (

--- a/web/src/services/map-service.ts
+++ b/web/src/services/map-service.ts
@@ -1,15 +1,13 @@
-export interface Coordinates {
-  lat: number;
-  lon: number;
-}
-
-const BASE_URL = 'https://nominatim.openstreetmap.org/search';
+import { type Coordinates } from '@/types/map';
 
 export const MapService = {
   async getCoordinates(location: string): Promise<Coordinates> {
-    const response = await fetch(`${BASE_URL}?format=json&q=${encodeURIComponent(location)}`, {
-      signal: AbortSignal.timeout(5000), // 5 second timeout
-    });
+    const response = await fetch(
+      `${import.meta.env.VITE_MAP_API_BASE_URL}?format=json&q=${encodeURIComponent(location)}`,
+      {
+        signal: AbortSignal.timeout(5000), // 5 second timeout
+      }
+    );
 
     if (!response.ok) {
       throw new Error(`Geocoding request failed: ${response.status}`);

--- a/web/src/services/map-service.ts
+++ b/web/src/services/map-service.ts
@@ -7,7 +7,12 @@ const BASE_URL = 'https://nominatim.openstreetmap.org/search';
 
 export const MapService = {
   async getCoordinates(location: string): Promise<Coordinates> {
-    const response = await fetch(`${BASE_URL}?format=json&q=${encodeURIComponent(location)}`);
+    const response = await fetch(
+      `${BASE_URL}?format=json&q=${encodeURIComponent(location)}`,
+      {
+        signal: AbortSignal.timeout(5000), // 5 second timeout
+      }
+    );
 
     if (!response.ok) {
       throw new Error(`Geocoding request failed: ${response.status}`);
@@ -15,13 +20,20 @@ export const MapService = {
 
     const data = await response.json();
 
-    if (!data || data.length === 0) {
+    const data = await response.json();
+
+    if (!Array.isArray(data) || data.length === 0) {
       throw new Error(`No coordinates found for location: "${location}"`);
     }
 
+    const firstResult = data[0];
+    if (!firstResult.lat || !firstResult.lon) {
+      throw new Error(`Invalid coordinates in response for location: "${location}"`);
+    }
+
     return {
-      lat: parseFloat(data[0].lat),
-      lon: parseFloat(data[0].lon),
+      lat: parseFloat(firstResult.lat),
+      lon: parseFloat(firstResult.lon),
     };
   },
 };

--- a/web/src/services/map-service.ts
+++ b/web/src/services/map-service.ts
@@ -1,0 +1,27 @@
+export interface Coordinates {
+  lat: number;
+  lon: number;
+}
+
+const BASE_URL = 'https://nominatim.openstreetmap.org/search';
+
+export const MapService = {
+  async getCoordinates(location: string): Promise<Coordinates> {
+    const response = await fetch(`${BASE_URL}?format=json&q=${encodeURIComponent(location)}`);
+
+    if (!response.ok) {
+      throw new Error(`Geocoding request failed: ${response.status}`);
+    }
+
+    const data = await response.json();
+
+    if (!data || data.length === 0) {
+      throw new Error(`No coordinates found for location: "${location}"`);
+    }
+
+    return {
+      lat: parseFloat(data[0].lat),
+      lon: parseFloat(data[0].lon),
+    };
+  },
+};

--- a/web/src/services/map-service.ts
+++ b/web/src/services/map-service.ts
@@ -7,18 +7,13 @@ const BASE_URL = 'https://nominatim.openstreetmap.org/search';
 
 export const MapService = {
   async getCoordinates(location: string): Promise<Coordinates> {
-    const response = await fetch(
-      `${BASE_URL}?format=json&q=${encodeURIComponent(location)}`,
-      {
-        signal: AbortSignal.timeout(5000), // 5 second timeout
-      }
-    );
+    const response = await fetch(`${BASE_URL}?format=json&q=${encodeURIComponent(location)}`, {
+      signal: AbortSignal.timeout(5000), // 5 second timeout
+    });
 
     if (!response.ok) {
       throw new Error(`Geocoding request failed: ${response.status}`);
     }
-
-    const data = await response.json();
 
     const data = await response.json();
 

--- a/web/src/test/map-service.test.ts
+++ b/web/src/test/map-service.test.ts
@@ -32,7 +32,8 @@ describe('MapService.getCoordinates', () => {
     await MapService.getCoordinates('Lviv, Ukraine');
 
     expect(mockFetch).toHaveBeenCalledWith(
-      'https://nominatim.openstreetmap.org/search?format=json&q=Lviv%2C%20Ukraine'
+      'https://nominatim.openstreetmap.org/search?format=json&q=Lviv%2C%20Ukraine',
+      { signal: AbortSignal.timeout(5000) }
     );
   });
 
@@ -56,5 +57,25 @@ describe('MapService.getCoordinates', () => {
     mockFetch.mockRejectedValueOnce(new Error('Network error'));
 
     await expect(MapService.getCoordinates('Kyiv')).rejects.toThrow('Network error');
+  });
+
+  it('throws when the response is not an array', async () => {
+    mockFetchResolving({ lat: '50.4501', lon: '30.5234' }); // object, not array
+
+    await expect(MapService.getCoordinates('Kyiv')).rejects.toThrow('No coordinates found');
+  });
+
+  it('throws when lat or lon properties are missing', async () => {
+    mockFetchResolving([{ lat: '50.4501' }]); // missing lon
+
+    await expect(MapService.getCoordinates('Kyiv')).rejects.toThrow();
+  });
+
+  it('handles non-numeric coordinate strings gracefully', async () => {
+    mockFetchResolving([{ lat: 'invalid', lon: '30.5234' }]);
+
+    const result = await MapService.getCoordinates('Kyiv');
+
+    expect(result.lat).toBeNaN(); // or verify error is thrown if validation added
   });
 });

--- a/web/src/test/map-service.test.ts
+++ b/web/src/test/map-service.test.ts
@@ -1,0 +1,60 @@
+import { MapService } from '@/services/map-service';
+
+const mockFetch = jest.fn();
+globalThis.fetch = mockFetch as typeof fetch; // another way for `global.fetch`
+
+const mockSuccessResponse = [{ lat: '50.4501', lon: '30.5234' }];
+
+function mockFetchResolving(body: unknown, ok = true) {
+  mockFetch.mockResolvedValueOnce({
+    ok,
+    status: ok ? 200 : 500,
+    json: async () => body,
+  });
+}
+
+beforeEach(() => {
+  mockFetch.mockClear();
+});
+
+describe('MapService.getCoordinates', () => {
+  it('returns parsed coordinates on a successful response', async () => {
+    mockFetchResolving(mockSuccessResponse);
+
+    const result = await MapService.getCoordinates('Kyiv, Ukraine');
+
+    expect(result).toEqual({ lat: 50.4501, lon: 30.5234 });
+  });
+
+  it('calls the Nominatim API with the encoded location', async () => {
+    mockFetchResolving(mockSuccessResponse);
+
+    await MapService.getCoordinates('Lviv, Ukraine');
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      'https://nominatim.openstreetmap.org/search?format=json&q=Lviv%2C%20Ukraine'
+    );
+  });
+
+  it('throws when the response is not ok', async () => {
+    mockFetchResolving([], false);
+
+    await expect(MapService.getCoordinates('Nowhere')).rejects.toThrow(
+      'Geocoding request failed: 500'
+    );
+  });
+
+  it('throws when the response returns an empty array', async () => {
+    mockFetchResolving([]);
+
+    await expect(MapService.getCoordinates('Nowhere')).rejects.toThrow(
+      'No coordinates found for location: "Nowhere"'
+    );
+  });
+
+  it('throws when fetch itself rejects (network error)', async () => {
+    mockFetch.mockRejectedValueOnce(new Error('Network error'));
+
+    await expect(MapService.getCoordinates('Kyiv')).rejects.toThrow('Network error');
+  });
+});

--- a/web/src/test/map-service.test.ts
+++ b/web/src/test/map-service.test.ts
@@ -32,7 +32,7 @@ describe('MapService.getCoordinates', () => {
     await MapService.getCoordinates('Lviv, Ukraine');
 
     expect(mockFetch).toHaveBeenCalledWith(
-      'https://nominatim.openstreetmap.org/search?format=json&q=Lviv%2C%20Ukraine',
+      `${import.meta.env.VITE_MAP_API_BASE_URL}?format=json&q=Lviv%2C%20Ukraine`,
       { signal: AbortSignal.timeout(5000) }
     );
   });

--- a/web/src/types/map.ts
+++ b/web/src/types/map.ts
@@ -1,0 +1,4 @@
+export interface Coordinates {
+  lat: number;
+  lon: number;
+}


### PR DESCRIPTION
## Description
Moved event location coordinates fetching to a dedicated `MapService` and added Jest tests to ensure it works as intended.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized location-to-coordinates resolution into a dedicated map service used by the event location UI.

* **Reliability**
  * Geocoding requests now use a timeout and provide clearer error paths for HTTP failures, empty results, and malformed responses.

* **Tests**
  * Added comprehensive tests for geocoding behavior (successful lookups, URL encoding, HTTP errors, empty results, malformed payloads, and network failures).

* **Configuration**
  * Added a map API base URL environment variable example.

* **Types**
  * Introduced a numeric coordinates type for geocoding results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->