### PR TITLE
fix: resolve params access and add file validation for uploads

### DIFF
--- a/api/app/controllers/api/v1/brands_controller.rb
+++ b/api/app/controllers/api/v1/brands_controller.rb
@@ -88,23 +88,15 @@ module Api
         file = attrs[:logo]
 
         if file.present? && file.is_a?(ActionDispatch::Http::UploadedFile)
-          allowed_types = %w[
-            image/jpeg 
-            image/png 
-            image/webp 
-            image/gif 
-            image/svg+xml
-          ]
+          allowed_types = %w[image/jpeg image/png image/webp image/gif image/svg+xml]
+
           unless file.content_type.in?(allowed_types)
             raise MediaUploadError, 'Invalid logo format. Allowed types: JPG, PNG, WEBP, GIF, SVG.'
           end
 
-          if file.size > 5.megabytes
-            raise MediaUploadError, 'Logo file size must be under 5MB.'
-          end
+          raise MediaUploadError, 'Logo file size must be under 5MB.' if file.size > 5.megabytes
 
           s3_key = S3BucketService.new.upload(file, folder: 'brands/logos')
-
           raise MediaUploadError, 'Failed to upload logo to cloud storage. Please try again.' if s3_key.nil?
 
           attrs[:logo] = s3_key

--- a/api/app/controllers/api/v1/brands_controller.rb
+++ b/api/app/controllers/api/v1/brands_controller.rb
@@ -7,8 +7,14 @@ module Api
     class BrandsController < ApplicationController
       include Paginatable
 
+      class MediaUploadError < StandardError; end
+
       rescue_from ActionController::ParameterMissing do |e|
         render json: { error: e.message }, status: :bad_request
+      end
+
+      rescue_from MediaUploadError do |e|
+        render json: { errors: [e.message] }, status: :unprocessable_content
       end
 
       before_action :set_brand, only: %i[update destroy]
@@ -78,9 +84,32 @@ module Api
       private
 
       def process_logo_upload(attrs)
-        if attrs[:logo].present? && attrs[:logo].is_a?(ActionDispatch::Http::UploadedFile)
-          attrs[:logo] = S3BucketService.new.upload(attrs[:logo], folder: 'brands/logos')
+        attrs = attrs.with_indifferent_access
+        file = attrs[:logo]
+
+        if file.present? && file.is_a?(ActionDispatch::Http::UploadedFile)
+          allowed_types = %w[
+            image/jpeg 
+            image/png 
+            image/webp 
+            image/gif 
+            image/svg+xml
+          ]
+          unless file.content_type.in?(allowed_types)
+            raise MediaUploadError, 'Invalid logo format. Allowed types: JPG, PNG, WEBP, GIF, SVG.'
+          end
+
+          if file.size > 5.megabytes
+            raise MediaUploadError, 'Logo file size must be under 5MB.'
+          end
+
+          s3_key = S3BucketService.new.upload(file, folder: 'brands/logos')
+
+          raise MediaUploadError, 'Failed to upload logo to cloud storage. Please try again.' if s3_key.nil?
+
+          attrs[:logo] = s3_key
         end
+
         attrs
       end
 

--- a/api/app/controllers/api/v1/events_controller.rb
+++ b/api/app/controllers/api/v1/events_controller.rb
@@ -58,29 +58,20 @@ module Api
         file = attrs[:banner]
 
         if file.present? && file.is_a?(ActionDispatch::Http::UploadedFile)
-          allowed_types = %w[
-            image/jpeg
-            image/png
-            image/webp
-            image/gif
-            image/svg+xml
-          ]
+          allowed_types = %w[image/jpeg image/png image/webp image/gif image/svg+xml]
 
           unless file.content_type.in?(allowed_types)
             raise MediaUploadError, 'Invalid banner format. Allowed types: JPG, PNG, WEBP, GIF, SVG.'
           end
 
-          if file.size > 5.megabytes
-            raise MediaUploadError, 'Banner file size must be under 5MB.'
-          end
+          raise MediaUploadError, 'Banner file size must be under 5MB.' if file.size > 5.megabytes
 
           s3_key = S3BucketService.new.upload(file, folder: 'events/banners')
-
           raise MediaUploadError, 'Failed to upload banner to cloud storage. Please try again.' if s3_key.nil?
 
           attrs[:banner] = s3_key
         end
-        
+
         attrs
       end
 

--- a/api/app/controllers/api/v1/events_controller.rb
+++ b/api/app/controllers/api/v1/events_controller.rb
@@ -1,9 +1,17 @@
 # frozen_string_literal: true
 
+# rubocop:disable Metrics/ClassLength
+
 module Api
   module V1
     class EventsController < ApplicationController
       include Paginatable
+
+      class MediaUploadError < StandardError; end
+
+      rescue_from MediaUploadError do |e|
+        render json: { errors: [e.message] }, status: :unprocessable_content
+      end
 
       before_action :set_event, only: [:show]
 
@@ -46,9 +54,33 @@ module Api
       end
 
       def process_banner_upload(attrs)
-        if attrs[:banner].present? && attrs[:banner].is_a?(ActionDispatch::Http::UploadedFile)
-          attrs[:banner] = S3BucketService.new.upload(attrs[:banner], folder: 'events/banners')
+        attrs = attrs.with_indifferent_access
+        file = attrs[:banner]
+
+        if file.present? && file.is_a?(ActionDispatch::Http::UploadedFile)
+          allowed_types = %w[
+            image/jpeg
+            image/png
+            image/webp
+            image/gif
+            image/svg+xml
+          ]
+
+          unless file.content_type.in?(allowed_types)
+            raise MediaUploadError, 'Invalid banner format. Allowed types: JPG, PNG, WEBP, GIF, SVG.'
+          end
+
+          if file.size > 5.megabytes
+            raise MediaUploadError, 'Banner file size must be under 5MB.'
+          end
+
+          s3_key = S3BucketService.new.upload(file, folder: 'events/banners')
+
+          raise MediaUploadError, 'Failed to upload banner to cloud storage. Please try again.' if s3_key.nil?
+
+          attrs[:banner] = s3_key
         end
+        
         attrs
       end
 
@@ -124,3 +156,4 @@ module Api
     end
   end
 end
+# rubocop:enable Metrics/ClassLength


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Brand logo uploads now validate file format and size requirements, rejecting unsupported formats or files exceeding 5MB
* Event banner uploads now validate file format and size requirements, rejecting unsupported formats or files exceeding 5MB
* Media upload failures now return structured error responses for better user feedback

<!-- end of auto-generated comment: release notes by coderabbit.ai -->