### PR TITLE
Add tests for API and web payment functionality

### DIFF
--- a/api/app/controllers/api/v1/payments_controller.rb
+++ b/api/app/controllers/api/v1/payments_controller.rb
@@ -2,8 +2,10 @@
 
 module Api
   module V1
+    # rubocop:disable Metrics/ClassLength
     class PaymentsController < ApplicationController
       skip_before_action :authorize_request, only: [:webhook]
+      before_action :require_authentication!, only: [:create]
 
       def create
         event = Event.find(params[:event_id])
@@ -25,11 +27,10 @@ module Api
 
         payload = parse_webhook_payload
         return if payload.is_a?(ActionDispatch::Response)
-
         return head :ok unless payload['status'] == 'success'
 
-        process_successful_payment(payload)
-        head :ok
+        result = process_successful_payment(payload)
+        head :ok unless result == false
       end
 
       private
@@ -77,9 +78,11 @@ module Api
 
       def process_successful_payment(payload)
         reference = payload['reference']
-        # "event-1-user-2-qty-3"
         match = reference.match(/event-(\d+)-user-(\d+)-qty-(\d+)/)
-        return render json: { error: 'Invalid reference format' }, status: :bad_request unless match
+        unless match
+          render json: { error: 'Invalid reference format' }, status: :bad_request
+          return false
+        end
 
         event_id, user_id, quantity = match.captures
         quantity = quantity.to_i
@@ -87,8 +90,15 @@ module Api
         user  = User.find_by(id: user_id)
         event = Event.find_by(id: event_id)
 
-        return render json: { error: 'User not found' }, status: :not_found  unless user
-        return render json: { error: 'Event not found' }, status: :not_found unless event
+        unless user
+          render json: { error: 'User not found' }, status: :not_found
+          return false
+        end
+
+        unless event
+          render json: { error: 'Event not found' }, status: :not_found
+          return false
+        end
 
         create_tickets_for_user_and_event(user, event, quantity, payload['invoiceId'])
       end
@@ -132,5 +142,6 @@ module Api
         }
       end
     end
+    # rubocop:enable Metrics/ClassLength
   end
 end

--- a/api/spec/models/ticket_spec.rb
+++ b/api/spec/models/ticket_spec.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Ticket, type: :model do
+  subject { build(:ticket) }
+
+  it { is_expected.to belong_to(:user) }
+  it { is_expected.to belong_to(:event) }
+
+  it { is_expected.to validate_presence_of(:user_id) }
+  it { is_expected.to validate_presence_of(:event_id) }
+  it { is_expected.to validate_uniqueness_of(:qr_code) }
+  it { is_expected.to have_one(:event_feedback) }
+
+  it 'is active by default' do
+    ticket = create(:ticket)
+    expect(ticket.is_active).to be(true)
+  end
+
+  describe 'callbacks' do
+    it 'generates a qr_code before validation on create' do
+      ticket = build(:ticket, qr_code: nil)
+
+      expect(ticket.qr_code).to be_nil
+
+      ticket.valid?
+
+      expect(ticket.qr_code).to be_present
+    end
+
+    it 'returns qr_code_url when qr_image_key is present' do
+      ticket = build(:ticket, qr_image_key: 'tickets/qr/test.png')
+      allow_any_instance_of(S3BucketService).to receive(:file_url).with('tickets/qr/test.png').and_return('https://s3.example/test.png')
+
+      expect(ticket.qr_code_url).to eq('https://s3.example/test.png')
+    end
+  end
+
+  describe 'scopes' do
+    describe '.search_by_event' do
+      it 'returns all tickets when query is blank' do
+        t1 = create(:ticket)
+        expect(Ticket.search_by_event(nil)).to include(t1)
+      end
+
+      it 'filters tickets by event title' do
+        event = create(:event, title: 'RubyConf 2026')
+        other = create(:event, title: 'JS Fest')
+        t1 = create(:ticket, event: event)
+        t2 = create(:ticket, event: other)
+
+        results = Ticket.search_by_event('Ruby')
+        expect(results).to include(t1)
+        expect(results).not_to include(t2)
+      end
+    end
+
+    describe '.sorted_by' do
+      it 'sorts by allowed fields and direction' do
+        t1 = create(:ticket, created_at: 2.days.ago, is_active: true)
+        t2 = create(:ticket, created_at: 1.day.ago, is_active: false)
+
+        expect(Ticket.sorted_by('created_at', 'asc').first).to eq(t1)
+        expect(Ticket.sorted_by('created_at', 'desc').first).to eq(t2)
+
+        # fallback to created_at when unknown field provided
+        expect(Ticket.sorted_by('unknown_field', 'asc').first).to be_present
+      end
+
+      it 'defaults to desc when invalid direction provided' do
+        create(:ticket, created_at: 2.days.ago)
+        t2 = create(:ticket, created_at: 1.day.ago)
+
+        expect(Ticket.sorted_by('created_at', 'invalid').first).to eq(t2)
+      end
+    end
+  end
+end

--- a/api/spec/requests/api/v1/payments_spec.rb
+++ b/api/spec/requests/api/v1/payments_spec.rb
@@ -1,0 +1,229 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Api::V1::Payments', type: :request do
+  let(:user)    { create(:user, :confirmed) }
+  let(:event)   { create(:event, :published, price_cents: 10_000, available_tickets_count: 10) }
+  let(:token)   { JwtService.encode(user_id: user.id, password_salt: user.password_salt) }
+  let(:headers) { { 'Authorization' => "Bearer #{token}", 'Content-Type' => 'application/json' } }
+  let(:webhook_headers) { { 'Content-Type' => 'application/json', 'X-Sign' => 'valid_signature' } }
+
+  let(:monobank_success) do
+    { 'pageUrl' => 'https://pay.monobank.ua/invoice/abc', 'invoiceId' => 'inv_123' }
+  end
+
+  before do
+    allow(MonobankService).to receive(:create_invoice).and_return(monobank_success)
+    allow(MonobankService).to receive(:verify_webhook_signature).and_return(true)
+    allow(MailerService).to receive(:send_ticket_confirmation)
+  end
+
+  describe 'POST /api/v1/payments' do
+    context 'when unauthenticated' do
+      it 'returns 401' do
+        post '/api/v1/payments',
+             headers: { 'Content-Type' => 'application/json' }
+
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    context 'when authenticated and event is published' do
+      it 'returns pageUrl and invoiceId' do
+        post '/api/v1/payments',
+             params: { event_id: event.id, quantity: 1 }.to_json,
+             headers: headers
+
+        expect(response).to have_http_status(:ok)
+        expect(response.parsed_body['pageUrl']).to eq('https://pay.monobank.ua/invoice/abc')
+        expect(response.parsed_body['invoiceId']).to eq('inv_123')
+      end
+
+      it 'clamps quantity to 10 at most' do
+        post '/api/v1/payments',
+             params: { event_id: event.id, quantity: 99 }.to_json,
+             headers: headers
+
+        expect(MonobankService).to have_received(:create_invoice).with(
+          hash_including(amount_cents: event.price_cents * 10)
+        )
+      end
+
+      it 'defaults quantity to 1 when not provided' do
+        post '/api/v1/payments',
+             params: { event_id: event.id }.to_json,
+             headers: headers
+
+        expect(MonobankService).to have_received(:create_invoice).with(
+          hash_including(amount_cents: event.price_cents)
+        )
+      end
+    end
+
+    context 'when unauthenticated' do
+      it 'returns 401' do
+        post '/api/v1/payments',
+             headers: { 'Content-Type' => 'application/json' }
+
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    context 'when event is not published' do
+      let(:event) { create(:event, price_cents: 10_000, available_tickets_count: 10) }
+
+      it 'returns 422 with error message' do
+        post '/api/v1/payments',
+             params: { event_id: event.id }.to_json,
+             headers: headers
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response.parsed_body['error']).to eq('Event not available for purchase')
+      end
+    end
+
+    context 'when not enough tickets available' do
+      let(:event) { create(:event, :published, price_cents: 10_000, available_tickets_count: 2) }
+
+      it 'returns 422 with error message' do
+        post '/api/v1/payments',
+             params: { event_id: event.id, quantity: 5 }.to_json,
+             headers: headers
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response.parsed_body['error']).to eq('Not enough tickets available')
+      end
+    end
+
+    context 'when event is not found' do
+      it 'returns 404' do
+        post '/api/v1/payments',
+             params: { event_id: 99_999 }.to_json,
+             headers: headers
+
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+
+    context 'when Monobank returns an error' do
+      before do
+        allow(MonobankService).to receive(:create_invoice).and_return({ 'errCode' => '1001' })
+      end
+
+      it 'returns 422 with errCode' do
+        post '/api/v1/payments',
+             params: { event_id: event.id }.to_json,
+             headers: headers
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response.parsed_body['error']).to eq('1001')
+      end
+    end
+  end
+
+  describe 'POST /api/v1/payments/webhook' do
+    let(:invoice_id) { 'inv_123' }
+
+    let(:success_payload) do
+      {
+        status: 'success',
+        invoiceId: invoice_id,
+        reference: "event-#{event.id}-user-#{user.id}-qty-2"
+      }.to_json
+    end
+
+    around do |example|
+      original = Rails.cache
+      Rails.cache = ActiveSupport::Cache::MemoryStore.new
+      example.run
+      Rails.cache = original
+    end
+
+    context 'when payment is successful' do
+      it 'creates the correct number of tickets' do
+        expect do
+          post '/api/v1/payments/webhook',
+               params: success_payload,
+               headers: webhook_headers
+        end.to change { user.tickets.count }.by(2)
+
+        expect(response).to have_http_status(:ok)
+      end
+
+      it 'decrements available_tickets_count' do
+        post '/api/v1/payments/webhook',
+             params: success_payload,
+             headers: webhook_headers
+
+        expect(event.reload.available_tickets_count).to eq(8)
+      end
+
+      it 'sends a confirmation email per ticket' do
+        post '/api/v1/payments/webhook',
+             params: success_payload,
+             headers: webhook_headers
+
+        expect(MailerService).to have_received(:send_ticket_confirmation).twice
+      end
+
+      it 'is idempotent on repeated webhook calls' do
+        post '/api/v1/payments/webhook', params: success_payload, headers: webhook_headers
+
+        expect do
+          post '/api/v1/payments/webhook', params: success_payload, headers: webhook_headers
+        end.not_to(change { user.tickets.count })
+      end
+    end
+
+    context 'when payment status is not success' do
+      let(:processing_payload) do
+        {
+          status: 'processing',
+          invoiceId: invoice_id,
+          reference: "event-#{event.id}-user-#{user.id}-qty-2"
+        }.to_json
+      end
+
+      it 'does not create any tickets and returns 200' do
+        expect do
+          post '/api/v1/payments/webhook',
+               params: processing_payload,
+               headers: webhook_headers
+        end.not_to(change { Ticket.count })
+
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context 'when signature is invalid' do
+      before do
+        allow(MonobankService).to receive(:verify_webhook_signature).and_return(false)
+      end
+
+      it 'returns 401 and creates no tickets' do
+        expect do
+          post '/api/v1/payments/webhook',
+               params: success_payload,
+               headers: webhook_headers
+        end.not_to(change { Ticket.count })
+
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    context 'when reference format is invalid' do
+      let(:bad_payload) do
+        { status: 'success', invoiceId: invoice_id, reference: 'bad-format' }.to_json
+      end
+
+      it 'returns 400' do
+        post '/api/v1/payments/webhook',
+             params: bad_payload,
+             headers: webhook_headers
+
+        expect(response).to have_http_status(:bad_request)
+      end
+    end
+  end
+end

--- a/api/spec/services/monobank_service_spec.rb
+++ b/api/spec/services/monobank_service_spec.rb
@@ -1,0 +1,160 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe MonobankService do
+  let(:event) { create(:event, :published, title: 'Future Conf', price_cents: 10_000) }
+  let(:user)  { create(:user, :confirmed) }
+
+  let(:faraday_connection) { instance_double(Faraday::Connection) }
+  let(:faraday_response)   { instance_double(Faraday::Response) }
+
+  before do
+    allow(Faraday).to receive(:new).and_return(faraday_connection)
+  end
+
+  describe '.create_invoice' do
+    let(:invoice_attrs) do
+      {
+        amount_cents: 10_000,
+        order_id: "event-#{event.id}-user-#{user.id}-qty-1",
+        event: event,
+        quantity: 1,
+        redirect_url: 'http://localhost:5173/events/1',
+        webhook_url: 'http://localhost:3000/api/v1/payments/webhook'
+      }
+    end
+
+    let(:success_body) do
+      { 'pageUrl' => 'https://pay.monobank.ua/invoice/abc', 'invoiceId' => 'inv_123' }
+    end
+
+    before do
+      allow(faraday_response).to receive(:body).and_return(success_body)
+      allow(faraday_connection).to receive(:post).and_yield(
+        double('req', headers: {}).tap { |r| allow(r).to receive(:body=) }
+      ).and_return(faraday_response)
+    end
+
+    it 'returns pageUrl and invoiceId on success' do
+      result = described_class.create_invoice(invoice_attrs)
+
+      expect(result['pageUrl']).to eq('https://pay.monobank.ua/invoice/abc')
+      expect(result['invoiceId']).to eq('inv_123')
+    end
+
+    it 'sends the correct amount in kopecks' do
+      captured_body = nil
+      allow(faraday_connection).to receive(:post) do |&block|
+        req = double('req', headers: {})
+        allow(req).to receive(:body=) { |b| captured_body = b }
+        block.call(req)
+        faraday_response
+      end
+
+      described_class.create_invoice(invoice_attrs)
+
+      expect(captured_body[:amount]).to eq(10_000)
+      expect(captured_body[:ccy]).to eq(MonobankService::CURRENCY_CODE)
+    end
+
+    it 'sets basket item qty, sum per unit, and total correctly for multiple tickets' do
+      captured_body = nil
+      allow(faraday_connection).to receive(:post) do |&block|
+        req = double('req', headers: {})
+        allow(req).to receive(:body=) { |b| captured_body = b }
+        block.call(req)
+        faraday_response
+      end
+
+      described_class.create_invoice(invoice_attrs.merge(amount_cents: 30_000, quantity: 3))
+
+      item = captured_body.dig(:merchantPaymInfo, :basketOrder, 0)
+      expect(item[:qty]).to eq(3)
+      expect(item[:sum]).to eq(10_000)   # per unit
+      expect(item[:total]).to eq(30_000) # total
+    end
+
+    it 'sets validity and currency code' do
+      captured_body = nil
+      allow(faraday_connection).to receive(:post) do |&block|
+        req = double('req', headers: {})
+        allow(req).to receive(:body=) { |b| captured_body = b }
+        block.call(req)
+        faraday_response
+      end
+
+      described_class.create_invoice(invoice_attrs)
+
+      expect(captured_body[:validity]).to eq(MonobankService::INVOICE_VALIDITY)
+      expect(captured_body[:ccy]).to eq(MonobankService::CURRENCY_CODE)
+    end
+  end
+
+  describe '.verify_webhook_signature' do
+    let(:raw_body)  { '{"status":"success"}' }
+    let(:key_pair)  { OpenSSL::PKey::EC.generate('prime256v1') }
+    let(:signature) { Base64.encode64(key_pair.sign('SHA256', raw_body)) }
+
+    before do
+      allow(described_class).to receive(:fetch_public_key).and_return(key_pair)
+    end
+
+    it 'returns true for a valid signature' do
+      expect(described_class.verify_webhook_signature(raw_body, signature)).to be(true)
+    end
+
+    it 'returns false when X-Sign header is nil' do
+      expect(described_class.verify_webhook_signature(raw_body, nil)).to be(false)
+    end
+
+    it 'returns false when X-Sign header is empty string' do
+      expect(described_class.verify_webhook_signature(raw_body, '')).to be(false)
+    end
+
+    it 'returns false for a tampered body' do
+      expect(described_class.verify_webhook_signature('{"status":"failure"}', signature)).to be(false)
+    end
+
+    it 'returns false for a malformed signature' do
+      expect(described_class.verify_webhook_signature(raw_body, Base64.encode64('badsig'))).to be(false)
+    end
+  end
+
+  describe '.fetch_public_key' do
+    let(:key_pair)   { OpenSSL::PKey::EC.generate('prime256v1') }
+    let(:pubkey_b64) { Base64.encode64(key_pair.to_pem) }
+
+    around do |example|
+      Rails.cache = ActiveSupport::Cache::MemoryStore.new
+      example.run
+      Rails.cache = ActiveSupport::Cache::NullStore.new
+    end
+
+    it 'fetches and caches the public key from Monobank API' do
+      allow(faraday_connection).to receive(:get).and_yield(
+        double('req', headers: {})
+      ).and_return(
+        instance_double(Faraday::Response,
+                        success?: true,
+                        body: { 'key' => pubkey_b64 },
+                        status: 200)
+      )
+
+      key = described_class.fetch_public_key
+
+      expect(key).to be_a(OpenSSL::PKey::EC)
+      cached = Rails.cache.read(MonobankService::PUBLIC_KEY_CACHE_KEY)
+      expect(cached.to_der).to eq(key.to_der)
+    end
+
+    it 'returns cached key without hitting the API again' do
+      Rails.cache.write(MonobankService::PUBLIC_KEY_CACHE_KEY, key_pair)
+
+      expect(faraday_connection).not_to receive(:get)
+
+      result = described_class.fetch_public_key
+      expect(result.to_der).to eq(key_pair.to_der)
+    end
+  end
+end

--- a/web/src/test/payment-service.test.ts
+++ b/web/src/test/payment-service.test.ts
@@ -1,0 +1,71 @@
+import apiClient, { parseApiError } from '@/lib/api-client';
+import { PaymentService } from '@/services/payment-service';
+
+jest.mock('@/lib/api-client', () => ({
+  __esModule: true,
+  default: {
+    post: jest.fn(),
+  },
+  parseApiError: jest.fn((err: unknown) => {
+    throw err;
+  }),
+}));
+
+const mockedPost = apiClient.post as jest.Mock;
+const mockedParse = parseApiError as unknown as jest.Mock;
+
+describe('PaymentService', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('createInvoice: posts payload and returns response data', async () => {
+    const mockResp = { pageUrl: 'https://pay.example', invoiceId: 'inv-123' };
+    mockedPost.mockResolvedValueOnce({ data: mockResp });
+
+    const result = await PaymentService.createInvoice(5, 2);
+
+    expect(mockedPost).toHaveBeenCalledWith('/api/v1/payments', {
+      event_id: 5,
+      quantity: 2,
+    });
+
+    expect(result).toEqual(mockResp);
+  });
+
+  it('createInvoice: delegates error handling to parseApiError when request fails', async () => {
+    const err = new Error('network');
+    mockedPost.mockRejectedValueOnce(err);
+    mockedParse.mockImplementationOnce(() => {
+      throw new Error('parsed error');
+    });
+
+    await expect(PaymentService.createInvoice(1)).rejects.toThrow('parsed error');
+
+    expect(mockedPost).toHaveBeenCalledWith('/api/v1/payments', {
+      event_id: 1,
+      quantity: 1,
+    });
+    expect(mockedParse).toHaveBeenCalledWith(err);
+  });
+
+  it('createInvoice: uses quantity 1 as default', async () => {
+    mockedPost.mockResolvedValueOnce({
+      data: { pageUrl: 'https://pay.example', invoiceId: 'inv-123' },
+    });
+
+    await PaymentService.createInvoice(1);
+
+    expect(mockedPost).toHaveBeenCalledWith('/api/v1/payments', {
+      event_id: 1,
+      quantity: 1,
+    });
+  });
+
+  it('createInvoice: throws when response has no pageUrl', async () => {
+    mockedPost.mockResolvedValueOnce({ data: {} });
+
+    const result = await PaymentService.createInvoice(1);
+    expect(result).toEqual({});
+  });
+});

--- a/web/src/test/use-ticket-status.test.ts
+++ b/web/src/test/use-ticket-status.test.ts
@@ -1,0 +1,53 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { useTicketStatus } from '@/hooks/use-ticket-status';
+import { TicketsService } from '@/services/tickets-service';
+import { type Ticket } from '@/types/ticket';
+
+jest.mock('@/services/tickets-service');
+
+const mockGetMyTickets = jest.mocked(TicketsService.getMyTickets);
+
+describe('useTicketStatus', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('starts with isCheckingTicket true and then sets states when no tickets', async () => {
+    mockGetMyTickets.mockResolvedValueOnce({ data: [], meta: { page: 1, per_page: 20, total: 0 } });
+
+    const { result } = renderHook(() => useTicketStatus(5));
+
+    expect(result.current.isCheckingTicket).toBe(true);
+
+    await waitFor(() => expect(result.current.isCheckingTicket).toBe(false));
+
+    expect(mockGetMyTickets).toHaveBeenCalledWith({ event_id: 5 });
+    expect(result.current.hasBoughtTicket).toBe(false);
+    expect(result.current.ticket).toBeNull();
+  });
+
+  it('sets hasBoughtTicket true and ticket when tickets returned', async () => {
+    const ticket = { id: 't1', event_id: 5 } as Ticket;
+    mockGetMyTickets.mockResolvedValueOnce({
+      data: [ticket],
+      meta: { page: 1, per_page: 20, total: 1 },
+    });
+
+    const { result } = renderHook(() => useTicketStatus(5));
+
+    await waitFor(() => expect(result.current.isCheckingTicket).toBe(false));
+
+    expect(mockGetMyTickets).toHaveBeenCalledWith({ event_id: 5 });
+    expect(result.current.hasBoughtTicket).toBe(true);
+    expect(result.current.ticket).toEqual(ticket);
+  });
+
+  it('handles service error by setting isCheckingTicket false and leaving defaults', async () => {
+    mockGetMyTickets.mockRejectedValueOnce(new Error('Network'));
+
+    const { result } = renderHook(() => useTicketStatus(7));
+
+    await waitFor(() => expect(result.current.isCheckingTicket).toBe(false));
+
+    expect(result.current.hasBoughtTicket).toBe(false);
+    expect(result.current.ticket).toBeNull();
+  });
+});


### PR DESCRIPTION
## Description
This PR aims to add a new set of tests for both `api/` and `web/` regarding payment functionality.

## Covered
- `monobank_service.rb`
- `payments_controller.rb`
- `payment-service.ts`
- `use-ticket-status.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Payment creation now requires user authentication.

* **Bug Fixes**
  * Improved webhook idempotency to prevent duplicate ticket creation.
  * Refined error handling for invalid payment references and missing data.

* **Tests**
  * Added comprehensive test coverage for payment API endpoints, webhook processing, and ticket management functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->