### PR TITLE
Enhance event detail page with banner retrieval

### DIFF
--- a/api/app/controllers/api/v1/events_controller.rb
+++ b/api/app/controllers/api/v1/events_controller.rb
@@ -101,7 +101,7 @@ module Api
 
       def event_serialization_includes
         {
-          brand: { only: %i[id name] },
+          brand: { only: %i[id name primary_color secondary_color] },
           categories: { only: %i[id name] }
         }
       end

--- a/web/src/components/layout/page-wrapper.tsx
+++ b/web/src/components/layout/page-wrapper.tsx
@@ -7,11 +7,19 @@ import { Sidebar } from '@/components/layout/sidebar/sidebar.tsx';
 interface PageWrapperProps {
   children: React.ReactNode;
   className?: string;
+  gradientColors?: { primary?: string; secondary?: string };
 }
 
-export function PageWrapper({ children, className }: PageWrapperProps) {
+export function PageWrapper({ children, className, gradientColors }: PageWrapperProps) {
+  const gradientStyle =
+    gradientColors?.primary && gradientColors?.secondary
+      ? {
+          background: `linear-gradient(135deg, ${gradientColors.primary} 0%, ${gradientColors.secondary} 100%)`,
+        }
+      : {};
+
   return (
-    <div className="flex min-h-screen flex-col bg-neutral-50">
+    <div className="flex min-h-screen flex-col bg-neutral-50" style={gradientStyle}>
       <Header />
       <div className="flex flex-1">
         <Sidebar />

--- a/web/src/pages/event-detail-page.tsx
+++ b/web/src/pages/event-detail-page.tsx
@@ -61,7 +61,7 @@ export function EventDetailPage() {
         secondary: eventDetail.brand?.secondary_color,
       }}
     >
-      <div className="min-h-screen min-w-2xl bg-white max-w-3xl mx-auto">
+      <div className="min-h-screen bg-white max-w-3xl mx-auto">
         <EventHero event={eventDetail} onBack={() => navigate('/events')} />
 
         <div className="px-5 pb-10">

--- a/web/src/pages/event-detail-page.tsx
+++ b/web/src/pages/event-detail-page.tsx
@@ -55,8 +55,13 @@ export function EventDetailPage() {
   }
 
   return (
-    <PageWrapper>
-      <div className="min-h-screen min-w-screen bg-white max-w-lg mx-auto">
+    <PageWrapper
+      gradientColors={{
+        primary: eventDetail.brand?.primary_color,
+        secondary: eventDetail.brand?.secondary_color,
+      }}
+    >
+      <div className="min-h-screen min-w-2xl bg-white max-w-3xl mx-auto">
         <EventHero event={eventDetail} onBack={() => navigate('/events')} />
 
         <div className="px-5 pb-10">

--- a/web/src/services/events-service.ts
+++ b/web/src/services/events-service.ts
@@ -35,6 +35,7 @@ export const EventsService = {
 
   async getEventById(id: number): Promise<EventDetail> {
     const response = await apiClient.get(`/api/v1/events/${id}`);
+    console.log(response.data);
     return response.data;
   },
 

--- a/web/src/services/events-service.ts
+++ b/web/src/services/events-service.ts
@@ -35,7 +35,6 @@ export const EventsService = {
 
   async getEventById(id: number): Promise<EventDetail> {
     const response = await apiClient.get(`/api/v1/events/${id}`);
-    console.log(response.data);
     return response.data;
   },
 

--- a/web/src/types/event.ts
+++ b/web/src/types/event.ts
@@ -28,6 +28,8 @@ export interface EventDetail extends Event {
     id: number;
     name: string;
     logoUrl?: string;
+    primary_color?: string;
+    secondary_color?: string;
   };
   categories: {
     id: number;


### PR DESCRIPTION
## Description
This PR updates the size of event details section, as well as ensures that event banner and brand-colors-gradient are properly displayed on the page.

## Display Example
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/428d201e-d1e3-47f4-8da4-99c419054b0f" />

P.S.
Sorry for notif, too lazy to re-do the screenshot :P

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Event detail pages now support brand colors for a more customized visual experience.
  * Event branding can now include primary and secondary colors in the displayed event data.

* **UI Improvements**
  * Event detail pages now use a gradient background when brand colors are available.
  * The event detail layout has been adjusted for a wider, more centered content area.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->